### PR TITLE
Fix title column

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -67,6 +67,7 @@ get_notifs() {
         local_page_size=$num_notifications
     fi
     printf >&2 "." # "marching ants" because sometimes this takes a bit.
+    # timefmt must use the reference time Mon Jan 2 15:04:05 MST 2006 to format a given time
     gh api -X GET /notifications --cache=20s \
         -f per_page="$local_page_size" -f all="$include_all_flag" -f participating="$only_participating_flag" -f page="$page_num" \
         --template '

--- a/gh-notify
+++ b/gh-notify
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 set -e -o pipefail
 
-GREEN='\033[0;32m'
-BLUE='\033[1;34m'
-GRAY='\033[0;30m'
-NC='\033[0m'
-
 help() {
     cat <<EOF
 Usage: gh notify [--flags]
@@ -76,57 +71,49 @@ get_notifs() {
         -f per_page="$local_page_size" -f all="$include_all_flag" -f participating="$only_participating_flag" -f page="$page_num" \
         --template '
     {{- range . -}}
-        {{- printf "%s\t%s\t%s\t" .updated_at .subject.type .subject.title -}}
-        {{- printf "%s\t" .repository.full_name -}}
-        {{- printf "%s\n" .subject.url -}}
+        {{- printf "%s\t%s\t%s\t" (timefmt "02/Jan/06" .updated_at | color "gray+h") .subject.type .subject.title -}}
+        {{- printf "%s\t" (.repository.full_name | color "blue+b") -}}
+        {{- printf "%s\n" (.subject.url | color "green") }}
     {{- end -}}'
 }
 
 print_notifs() {
-    local timestamp type title repo url
+    local timefmt type title repo url
     all_notifs=""
     page_num=1
     while true; do
-      page=$(get_notifs $page_num)
-      if [ "$page" == "" ]; then
-          break
-      else
-          page_num=$((page_num + 1))
-      fi
-      new_notifs=`
-      echo "$page" | while IFS=$'\t' read -r timestamp type title repo url; do
-            time="${timestamp:5:11}"
-            case "$type" in
-                "PullRequest" | "Issue")
-                    printf "${GRAY}%s${NC}\t${BLUE}%s${NC}\t%s ${GREEN}#%s${NC}\t%s\n" \
-                        "${time/T/ }" "${repo}" "${type}" "${url##*/}" "${title}"
-                    ;;
-                *)
-                    printf "${GRAY}%s${NC}\t${BLUE}%s${NC}\t%s \t%s\n" \
-                        "${time/T/ }" "${repo}" "${type}" "${title}"
-                    ;;
-            esac
-      done`
-      all_notifs="$all_notifs $new_notifs"
-      # this is going to be a bit funky.
-      # if you specify a number larger than 100
-      # GitHub will ignore it and give you only 100
-      if [ "$num_notifications" != "0" ]; then
-          break
-      fi
+        page=$(get_notifs $page_num)
+        if [ "$page" == "" ]; then
+            break
+        else
+            page_num=$((page_num + 1))
+        fi
+        new_notifs=$(
+            echo "$page" | while IFS=$'\t' read -r timefmt type title repo url; do
+                # "${url/http*\//#}" keep the green color but remove everything between http and the very last slash symbol
+                printf "%s\t%s\t%s %s\t%s\n" "${timefmt}" "${repo}" "${type}" "${url/http*\//#}" "${title}"
+            done
+        )
+        all_notifs="$all_notifs$new_notifs"
+        # this is going to be a bit funky.
+        # if you specify a number larger than 100
+        # GitHub will ignore it and give you only 100
+        if [ "$num_notifications" != "0" ]; then
+            break
+        fi
     done
     # clear the dots we printed
-    >&2 echo -e "\r\033[K"
+    echo >&2 -e "\r\033[K"
     # the different pages frequently come back with different
     # column widths.
     # If we insert a tab before the notification type
     # and recolumnize on that everything works out.
-    echo "$all_notifs" \
-        | sed -e "s/ Issue / \tIssue /" \
-              -e "s/ PullRequest / \tPullRequest /" \
-              -e "s/ Commit / \tCommit /" \
-              -e "s/ Release / \tRelease /" \
-        | column -t -s $'\t'
+    echo "$all_notifs" |
+        sed -e "s/ Issue / \tIssue /" \
+            -e "s/ PullRequest / \tPullRequest /" \
+            -e "s/ Commit / \tCommit /" \
+            -e "s/ Release / \tRelease /" |
+        column -t -s $'\t'
 }
 
 filtered_notifs() {
@@ -146,7 +133,7 @@ mark_notifs_read() {
 
 gh_info() {
     local repo type num
-    read -r _ _ repo type num _
+    read -r _ repo type num _
     if [[ $open_browser_view == "true" ]]; then
         case $type in
         "PullRequest" | "Issue")
@@ -168,7 +155,6 @@ gh_info() {
             gh release view -R "${repo}"
             ;;
         *) ;;
-
         esac
     fi
 }

--- a/gh-notify
+++ b/gh-notify
@@ -91,7 +91,8 @@ print_notifs() {
         fi
         new_notifs=$(
             echo "$page" | while IFS=$'\t' read -r timefmt type title repo url; do
-                # "${url/http*\//#}" keep the green color but remove everything between http and the very last slash symbol
+                # "${variable//search/replace}" keep the green color but remove everything between http and the very last slash symbol
+                # https://wiki.bash-hackers.org/syntax/pe
                 printf "%s\t%s\t%s %s\t%s\n" "${timefmt}" "${repo}" "${type}" "${url/http*\//#}" "${title}"
             done
         )

--- a/gh-notify
+++ b/gh-notify
@@ -72,7 +72,7 @@ get_notifs() {
         -f per_page="$local_page_size" -f all="$include_all_flag" -f participating="$only_participating_flag" -f page="$page_num" \
         --template '
     {{- range . -}}
-        {{- printf "%s\t%s\t%s\t" (timefmt "02/Jan/06" .updated_at | color "gray+h") .subject.type .subject.title -}}
+        {{- printf "%s\t%s\t%s\t" (timefmt "02/Jan 15:04" .updated_at | color "gray+h") .subject.type .subject.title -}}
         {{- printf "%s\t" (.repository.full_name | color "blue+b") -}}
         {{- if eq .subject.type "Release" -}} {{- printf "%s\n" ("✓" | color "green") -}}
         {{- else -}} {{- printf "%s\n" (.subject.url | color "green") -}} {{- end -}}
@@ -94,7 +94,7 @@ print_notifs() {
             echo "$page" | while IFS=$'\t' read -r timefmt type title repo url; do
                 # "${variable//search/replace}" keep the green color but remove everything between http and the very last slash symbol
                 # https://wiki.bash-hackers.org/syntax/pe
-                printf "%s\t%s\t%s %s\t%s\n" "${timefmt}" "${repo}" "${type}" "${url/http*\//#}" "${title}"
+                printf "\n%s\t%s\t%s %s\t%s\n" "${timefmt}" "${repo}" "${type}" "${url/http*\//#}" "${title}"
             done
         )
         all_notifs="$all_notifs$new_notifs"
@@ -136,7 +136,7 @@ mark_notifs_read() {
 
 gh_info() {
     local repo type num
-    read -r _ repo type num _
+    read -r _ _ repo type num _
     if [[ $open_browser_view == "true" ]]; then
         case $type in
         "PullRequest" | "Issue")

--- a/gh-notify
+++ b/gh-notify
@@ -73,7 +73,8 @@ get_notifs() {
     {{- range . -}}
         {{- printf "%s\t%s\t%s\t" (timefmt "02/Jan/06" .updated_at | color "gray+h") .subject.type .subject.title -}}
         {{- printf "%s\t" (.repository.full_name | color "blue+b") -}}
-        {{- printf "%s\n" (.subject.url | color "green") }}
+        {{- if eq .subject.type "Release" -}} {{- printf "%s\n" ("✓" | color "green") -}}
+        {{- else -}} {{- printf "%s\n" (.subject.url | color "green") -}} {{- end -}}
     {{- end -}}'
 }
 


### PR DESCRIPTION
## description
Fix #12
As seen in the referenced issue the title column is offset to the right for all types without a number.

## changes
- the fix moves more code from `print_notifs` to the `template` of the `gh api` call.
  - I think this makes the code easier to read and fixes the `backticks` problem mentioned in PR #10.
- The coloring is also done within the `template` and does not have to be defined in the shell anymore.
- Time format has been changed to `dd/MMM HH:mm` as this is easier to read for both Americans and Europeans, happy to restore the old format if you wish or even better changing it to use the `timeago` function (see [gh formatting](https://cli.github.com/manual/gh_help_formatting)).
- For `Release` types they get a `✓` tick symbol.

<img src="https://ttm.sh/wH9.jpg" width="600">

## code quality
### Used extensions
- spelling [Code Spell Checker](https://github.com/streetsidesoftware/vscode-spell-checker)
- formatting [shell-format](https://github.com/foxundermoon/vs-shell-format)
- linting [vscode-shellcheck](https://github.com/vscode-shellcheck/vscode-shellcheck)
