### PR TITLE
view notifications with fzf preview

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -134,7 +134,7 @@ select_notif() {
     fi
     # GH_FORCE_TTY enable terminal-style output even when the output is redirected.
     # See the man page (man fzf) for an explanation of the arguments.
-    GH_FORCE_TTY=50% fzf --ansi --exact --no-multi --reverse --header-first --info=inline \
+    GH_FORCE_TTY=50% fzf --ansi --no-multi --reverse --header-first --info=inline \
         --header "$fzf_header_description" \
         --margin 2% --border --color 'border:#778899' --preview-window wrap:hidden:40%:up:border-bottom \
         --bind '?:toggle-preview' \

--- a/gh-notify
+++ b/gh-notify
@@ -136,7 +136,7 @@ select_notif() {
     # See the man page (man fzf) for an explanation of the arguments.
     GH_FORCE_TTY=50% fzf --ansi --exact --no-multi --reverse --header-first --info=inline \
         --header "$fzf_header_description" \
-        --margin 2 --border --color 'border:#778899' --preview-window wrap:hidden:40%:up:border-bottom \
+        --margin 2% --border --color 'border:#778899' --preview-window wrap:hidden:40%:up:border-bottom \
         --bind '?:toggle-preview' \
         --preview "if grep -qo Issue <<< {}; then gh issue view {5} -R {3}; elif grep -qo PullRequest <<<{}; then gh pr view {5} -R {3}; else echo \"Move Along, Nothing To See.\"; fi" <<<"$notifs"
 }

--- a/gh-notify
+++ b/gh-notify
@@ -124,10 +124,21 @@ filtered_notifs() {
 }
 
 select_notif() {
-    local notifs
+    local notifs fzf_header_description
     notifs="$(filtered_notifs)"
     [ -n "$notifs" ] || exit 0
-    fzf --ansi <<<"$notifs"
+
+    fzf_header_description="Press Enter to view the notification (? Toggle preview)"
+    if [[ $open_browser_view == "true" ]]; then
+        fzf_header_description="Press Enter to open the notification in your browser (? Toggle preview)"
+    fi
+    # GH_FORCE_TTY enable terminal-style output even when the output is redirected.
+    # See the man page (man fzf) for an explanation of the arguments.
+    GH_FORCE_TTY=50% fzf --ansi --exact --no-multi --reverse --header-first --info=inline \
+        --header "$fzf_header_description" \
+        --margin 2 --border --color 'border:#778899' --preview-window wrap:hidden:40%:up:border-bottom \
+        --bind '?:toggle-preview' \
+        --preview "if grep -qo Issue <<< {}; then gh issue view {5} -R {3}; elif grep -qo PullRequest <<<{}; then gh pr view {5} -R {3}; else echo \"Move Along, Nothing To See.\"; fi" <<<"$notifs"
 }
 
 mark_notifs_read() {
@@ -149,10 +160,10 @@ gh_info() {
     else
         case $type in
         "PullRequest")
-            gh pr view "${num#\#}" -R "${repo}"
+            gh pr view "${num#\#}" -R "${repo}" --comments
             ;;
         "Issue")
-            gh issue view "${num#\#}" -R "${repo}"
+            gh issue view "${num#\#}" -R "${repo}" --comments
             ;;
         "Release")
             gh release view -R "${repo}"


### PR DESCRIPTION
Hello,

`fzf` is a powerful tool, since it is already included in the project, it could be made even more useful.

### Description
This PR aims to allow toggling the preview of an issue/PR with `fzf`. See GIF below for more clarity.

All styling options are not set in stone, it's just my preference for what looks good. Your repo, your call. Happy to make changes.

I took some inspiration from:
- [gh-dash](https://github.com/dlvhdr/gh-dash)
- [zoxide](https://github.com/ajeetdsouza/zoxide/blob/e4b9e12b0f28997b683ab50905c402c5f5c4a17c/src/util.rs)
- [random git repos](https://github.com/search?p=1&q=fzf+preview&type=Commits)


### Explaination for used Arguments
- `GH_FORCE_TTY=50%`
  - to enable terminal-style output even when the output is redirected.
  - https://github.com/cli/cli/pull/4146
- `--ansi --no-multi --reverse --header-first --info=inline`
  - `ansi` ...
  - `no-multi` ...
  - `reverse` seems to be more consistent, since any output with the `-s` flag also sorts them from top to bottom
  - `header-first` the header description should be at the top
  - `info=inline` the number of results is in the same line as the search
- `--header`
  - Depending on whether the `-o` flag is set, the description explains what pressing the `Enter` key does
- `--margin 2% --border --color 'border:#778899'`
  - some formatting
- `--preview-window wrap:hidden:40%:up:border-bottom`
  - `wrap` makes sure that the lines are not truncated
  - `hidden` by default the preview window is hidden
  - `40%:up:border-bottom` positioning on top with a border below the preview window
- `--bind '?:toggle-preview'`
  - toggles the window with the question mark `?`
- `--preview "if grep -qo Issue <<< {}; then gh issue view {5} -R {3}; elif grep -qo PullRequest <<<{}; then gh pr view {5} -R {3}; else echo \"Move Along, Nothing To See.\"; fi"`
  - It works, but looks a bit messy :worried:
  - The dummy text "Move Along, Nothing To See." can be removed, but then the window would be empty. I left it in for now as a joke.

### GIF
<img src="https://ttm.sh/qE-.gif" width="600">

### Asciinema
The same as the GIF, but it will be dead within 7 days. I like this better because you can pause the "video" and even copy the commands directly from it. I should create an account there. :grinning:
[![asciicast](https://asciinema.org/a/eLgQX04VXVGhmE0TopKNKnGnw.svg)](https://asciinema.org/a/eLgQX04VXVGhmE0TopKNKnGnw)
