### PR TITLE
Allow to preview release infos with fzf

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -128,17 +128,19 @@ select_notif() {
     notifs="$(filtered_notifs)"
     [ -n "$notifs" ] || exit 0
 
-    fzf_header_description="Press Enter to view the notification (? Toggle preview)"
+    fzf_header_description="Press Enter to view the notification. (? Toggle preview)"
     if [[ $open_browser_view == "true" ]]; then
-        fzf_header_description="Press Enter to open the notification in your browser (? Toggle preview)"
+        fzf_header_description="Press Enter to open the notification in your browser. (? Toggle preview)"
     fi
     # GH_FORCE_TTY enable terminal-style output even when the output is redirected.
     # See the man page (man fzf) for an explanation of the arguments.
+    # TODO: Release types without a tag name show only the information about the latest release.
     GH_FORCE_TTY=50% fzf --ansi --no-multi --reverse --header-first --info=inline \
         --header "$fzf_header_description" \
-        --margin 2% --border --color 'border:#778899' --preview-window wrap:hidden:40%:up:border-bottom \
+        --margin 2% --border --color 'border:#778899' \
+        --preview-window wrap:hidden:40%:up:border-bottom \
         --bind '?:toggle-preview' \
-        --preview "if grep -qo Issue <<< {}; then gh issue view {5} -R {3}; elif grep -qo PullRequest <<<{}; then gh pr view {5} -R {3}; else echo \"Move Along, Nothing To See.\"; fi" <<<"$notifs"
+        --preview "echo \[{4}\] ;if grep -q Issue <<<{4}; then gh issue view {5} -R {3}; elif grep -q PullRequest <<<{4}; then gh pr view {5} -R {3}; elif grep -q Release <<<{4}; then gh release view -R {3}; else echo {}; fi" <<<"$notifs"
 }
 
 mark_notifs_read() {


### PR DESCRIPTION
### Description
1. A small follow-up to yesterday's PR. The release type also gets a preview, but there is a small problem with it. Release types without tag names only show the information about the last version. I added a `TODO` note to this, maybe I will find a solution, but for now I am happy with the status quo that only the latest information is shown.

The following image illustrates the problem with the `release` type information.

<img src="https://ttm.sh/qQw.jpg" width="600">

2. The dummy text `Move Along, Nothing To See` for notification types other than `Issue`, `PullRequest` and `Release` has been replaced with the actual notification.  See image below for more clarity.

<img src="https://ttm.sh/qQq.47.jpg" width="600">
