### PR TITLE
fzf hotkey extension

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -130,7 +130,7 @@ select_notif() {
     # GH_FORCE_TTY enable terminal-style output even when the output is redirected.
     # See the man page (man fzf) for an explanation of the arguments.
     # TODO: Release types without a tag name show only the information about the latest release.
-    GH_FORCE_TTY=50% fzf --ansi --no-multi --reverse --info=inline \
+    GH_FORCE_TTY=50% fzf --ansi --no-multi --reverse --info=inline --header-first \
         --header "ENTER - View | CTRL+B - Browser view | ? - Toggle preview | CTRL+W/S Preview up/down" \
         --margin 2% --border --color "border:#778899" \
         --preview-window wrap:"$preview_window_visibility":50%:right:border-left \

--- a/gh-notify
+++ b/gh-notify
@@ -10,7 +10,7 @@ Select a pull request or issue to get more info on it.
 
 Flags:
     -a      include all notifications
-    -o      open the notification in your browser
+    -w      display the fzf preview window (default: hidden)
     -e      exclude notifications matching a string
             Ex. gh notify -e "MyDayJob"
     -f      filter to only notifications matching a string
@@ -28,7 +28,7 @@ EOF
 }
 
 include_all_flag='false'
-open_browser_view='false'
+preview_window_visibility='hidden'
 only_participating_flag='false'
 print_static_flag='false'
 mark_read_flag='false'
@@ -36,13 +36,13 @@ num_notifications='0'
 exclusion_string='XXX_BOGUS_STRING_THAT_SHOULD_NOT_EXIST_XXX'
 filter_string=''
 
-while getopts 'e:f:n:paohsr' flag; do
+while getopts 'e:f:n:pawhsr' flag; do
     case "${flag}" in
     n) num_notifications="${OPTARG}" ;;
     e) exclusion_string="${OPTARG}" ;;
     f) filter_string="${OPTARG}" ;;
     a) include_all_flag='true' ;;
-    o) open_browser_view='true' ;;
+    w) preview_window_visibility='nohidden' ;;
     p) only_participating_flag='true' ;;
     s) print_static_flag='true' ;;
     r) mark_read_flag='true' ;;
@@ -124,22 +124,19 @@ filtered_notifs() {
 }
 
 select_notif() {
-    local notifs fzf_header_description
+    local notifs
     notifs="$(filtered_notifs)"
     [ -n "$notifs" ] || exit 0
-
-    fzf_header_description="Press Enter to view the notification. (? Toggle preview)"
-    if [[ $open_browser_view == "true" ]]; then
-        fzf_header_description="Press Enter to open the notification in your browser. (? Toggle preview)"
-    fi
     # GH_FORCE_TTY enable terminal-style output even when the output is redirected.
     # See the man page (man fzf) for an explanation of the arguments.
     # TODO: Release types without a tag name show only the information about the latest release.
-    GH_FORCE_TTY=50% fzf --ansi --no-multi --reverse --header-first --info=inline \
-        --header "$fzf_header_description" \
-        --margin 2% --border --color 'border:#778899' \
-        --preview-window wrap:hidden:40%:up:border-bottom \
-        --bind '?:toggle-preview' \
+    GH_FORCE_TTY=50% fzf --ansi --no-multi --reverse --info=inline \
+        --header "ENTER - View | CTRL+B - Browser view | ? - Toggle preview | CTRL+W/S Preview up/down" \
+        --margin 2% --border --color "border:#778899" \
+        --preview-window wrap:"$preview_window_visibility":50%:right:border-left \
+        --bind "?:toggle-preview" \
+        --bind "ctrl-w:preview-up,ctrl-s:preview-down" \
+        --bind "ctrl-b:execute-silent:(if grep -q Issue <<<{4}; then gh issue view {5} -wR {3}; elif grep -q PullRequest <<<{4}; then gh pr view {5} -wR {3}; elif grep -q Release <<<{4}; then gh release view -wR {3}; else gh repo view -w {3}; fi)" \
         --preview "echo \[{4}\] ;if grep -q Issue <<<{4}; then gh issue view {5} -R {3}; elif grep -q PullRequest <<<{4}; then gh pr view {5} -R {3}; elif grep -q Release <<<{4}; then gh release view -R {3}; else echo {}; fi" <<<"$notifs"
 }
 
@@ -150,29 +147,18 @@ mark_notifs_read() {
 gh_info() {
     local repo type num
     read -r _ _ repo type num _
-    if [[ $open_browser_view == "true" ]]; then
-        case $type in
-        "PullRequest" | "Issue")
-            gh browse "${num#\#}" -R "${repo}"
-            ;;
-        *)
-            gh browse -R "${repo}"
-            ;;
-        esac
-    else
-        case $type in
-        "PullRequest")
-            gh pr view "${num#\#}" -R "${repo}" --comments
-            ;;
-        "Issue")
-            gh issue view "${num#\#}" -R "${repo}" --comments
-            ;;
-        "Release")
-            gh release view -R "${repo}"
-            ;;
-        *) ;;
-        esac
-    fi
+    case $type in
+    "PullRequest")
+        gh pr view "${num#\#}" -R "${repo}" --comments
+        ;;
+    "Issue")
+        gh issue view "${num#\#}" -R "${repo}" --comments
+        ;;
+    "Release")
+        gh release view -R "${repo}"
+        ;;
+    *) ;;
+    esac
 }
 
 if [[ $mark_read_flag == "true" ]]; then

--- a/gh-notify
+++ b/gh-notify
@@ -137,7 +137,7 @@ select_notif() {
         --bind "?:toggle-preview" \
         --bind "ctrl-w:preview-up,ctrl-s:preview-down" \
         --bind "ctrl-b:execute-silent:(if grep -q Issue <<<{4}; then gh issue view {5} -wR {3}; elif grep -q PullRequest <<<{4}; then gh pr view {5} -wR {3}; elif grep -q Release <<<{4}; then gh release view -wR {3}; else gh repo view -w {3}; fi)" \
-        --preview "echo \[{4}\] ;if grep -q Issue <<<{4}; then gh issue view {5} -R {3}; elif grep -q PullRequest <<<{4}; then gh pr view {5} -R {3}; elif grep -q Release <<<{4}; then gh release view -R {3}; else echo {}; fi" <<<"$notifs"
+        --preview 'echo \[{4}\] ;if grep -q Issue <<<{4}; then gh issue view {5} -R {3}; elif grep -q PullRequest <<<{4}; then gh pr view {5} -R {3}; elif grep -q Release <<<{4}; then gh release view -R {3}; else echo {} | sed "s/[ ]\\{3,\\}/  /g"; fi' <<<"$notifs"
 }
 
 mark_notifs_read() {

--- a/readme.md
+++ b/readme.md
@@ -34,4 +34,4 @@ Flags:
 Note: -e and -f both support GNU regular expressions.
 ```
 
-![demo](https://i.imgur.com/Lv308LC.gif)
+![demo](https://user-images.githubusercontent.com/92653266/185198672-6ae90682-b891-4fc4-b51e-0efbce427b46.gif)

--- a/readme.md
+++ b/readme.md
@@ -16,12 +16,12 @@ Install [fzf](https://github.com/junegunn/fzf) for interactive mode.
 > gh notify -h # help info
 Usage: gh notify [--flags]
 
-View and search and GitHub notifications.
+View and search GitHub notifications.
 Select a pull request or issue to get more info on it.
 
 Flags:
     -a      include all notifications
-    -o      open the notification in your browser
+    -w      display the`fzf` preview window (default: hidden)
     -e      exclude notifications matching a string
             Ex. gh notify -e "MyDayJob"
     -f      filter to only notifications matching a string

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ Select a pull request or issue to get more info on it.
 
 Flags:
     -a      include all notifications
-    -w      display the`fzf` preview window (default: hidden)
+    -w      display the fzf preview window (default: hidden)
     -e      exclude notifications matching a string
             Ex. gh notify -e "MyDayJob"
     -f      filter to only notifications matching a string


### PR DESCRIPTION
### Description
- Open the notification in the browser with a `fzf` key binding `ctrl+b`.
  - Main advantage: `fzf` stays open in the terminal and allows to open more notifications
- Replace the `-o` flag with the `-w` flag for `fzf` preview window visibility.
  - Toggling the preview window is always possible, but I guess some prefer it `hidden` others `not hidden`.
- Adding two more `fzf` hotkeys to move the preview window up and down `ctrl+w/s`.
  - quality of life addition instead of using the mouse to scroll
- The preview window was moved from the top to the right, looks better, right?
  - Easier reading, less scrolling required

### GIF
<img src="https://user-images.githubusercontent.com/92653266/185198672-6ae90682-b891-4fc4-b51e-0efbce427b46.gif" width="600">

