### PR TITLE
remove the percentage from top and bottom

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -142,13 +142,13 @@ select_notif() {
     notifs="$(filtered_notifs)"
     [ -n "$notifs" ] || exit 0
     open_notification_browser='if grep -qE "Issue|PullRequest" <<<{4}; then gh issue view {5} -wR {3}; elif grep -q Release <<<{4}; then gh release view -wR {3}; else gh repo view -w {3}; fi'
-    preview_notification='echo \[{1} {2} - {4}\] ;if grep -q Issue <<<{4}; then gh issue view {5} -R {3} --comments; elif grep -q PullRequest <<<\"{4}\"; then gh pr view {5} -R {3} --comments; elif grep -q Release <<<{4}; then gh release view -R {3}; else echo {} | sed "s/[ ]\\{3,\\}/  /g"; fi'
+    preview_notification='echo \[{1} {2} - {4}\] ;if grep -q Issue <<<{4}; then gh issue view {5} -R {3} --comments; elif grep -q PullRequest <<<\"{4}\"; then gh pr view {5} -R {3} --comments; elif grep -q Release <<<{4}; then gh release view -R {3}; else echo "Notification preview for {4} is not supported."; fi'
     # Enable terminal-style output even when the output is redirected.
     export GH_FORCE_TTY=100%
     # See the man page (man fzf) for an explanation of the arguments.
     # TODO: Release types without a tag name show only the information about the latest release.
     selection=$(fzf <<<"$notifs" --ansi --no-multi --reverse --info=inline \
-        --margin 2%,1%,2%,1% --pointer='▶' \
+        --margin 2,1%,2,1% --pointer='▶' \
         --border top --color "border:#778899" \
         --header $'? - Toggle Help\n\n' --color 'header:italic:dim' \
         --header-first --bind "change:first" \


### PR DESCRIPTION
Hello,

`fzf` has released version [0.34.0](https://github.com/junegunn/fzf/releases) which "added support for adaptive `--height`. [...]".
One limitation is:

```zsh
# Not compatible with percent top/bottom margin/padding
# This is not allowed (top/bottom margin in percent value)
fzf --height ~50% --border --margin 5%,10%

# This is allowed (top/bottom margin in fixed value)
fzf --height ~50% --border --margin 2,10%
```

### Why the change? :information_desk_person:

I put the `--height` flag with the new adaptive height in my `FZF_DEFAULT_OPTS` and when I run `gh notify -a` it would throw an error.

```zsh
❯ gh notify -a
# adaptive height is not compatible with top/bottom percent margin
```

:smile:
