### PR TITLE
cyan color for owner repo name

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -91,7 +91,7 @@ get_notifs() {
         --template '
     {{- range . -}}
         {{- printf "%s\t%s\t%s\t" (timefmt "02/Jan 15:04" .updated_at | color "gray+h") .subject.type .subject.title -}}
-        {{- printf "%s%s%s\t" (.repository.owner.login | color "blue+h") ("/" | color "gray") (.repository.name | color "blue+bh") -}}
+        {{- printf "%s%s%s\t" (.repository.owner.login | color "cyan") ("/" | color "gray") (.repository.name | color "cyan+b") -}}
         {{- if .subject.url -}}{{- printf "%s\t" .subject.url -}}{{- end -}}
         {{- if .unread -}} {{- printf "%s\n" ("●" | color "magenta") -}}
         {{- else -}} {{- printf "%s\n" (" " | color "magenta") -}} {{- end -}}

--- a/gh-notify
+++ b/gh-notify
@@ -91,7 +91,7 @@ get_notifs() {
         --template '
     {{- range . -}}
         {{- printf "%s\t%s\t%s\t" (timefmt "02/Jan 15:04" .updated_at | color "gray+h") .subject.type .subject.title -}}
-        {{- printf "%s%s%s\t" (.repository.owner.login | color "cyan") ("/" | color "gray") (.repository.name | color "cyan+b") -}}
+        {{- printf "%s%s%s\t" (.repository.owner.login | color "cyan+h") ("/" | color "gray+h") (.repository.name | color "cyan+hb") -}}
         {{- if .subject.url -}}{{- printf "%s\t" .subject.url -}}{{- end -}}
         {{- if .unread -}} {{- printf "%s\n" ("●" | color "magenta") -}}
         {{- else -}} {{- printf "%s\n" (" " | color "magenta") -}} {{- end -}}


### PR DESCRIPTION
As seen in the image posted by @rEnr3n in issue #23, the `blue` color has poor contrast on a dark background, the `owner/repo` string might look better with `cyan`.


<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/1cf49abbf11f6c052468279c7702035527f95842/storage/2022-11-01_11-01-16_cyan.png" width="600">
