### PR TITLE
browser hotkey extension

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -4,6 +4,16 @@ set -e -o pipefail
 GREEN='\033[0;32m'
 NC='\033[0m'
 
+# Enable terminal-style output even when the output is redirected.
+export GH_FORCE_TTY=100%
+# Disable the gh pager
+export GH_PAGER="cat"
+
+# NotificationReason:
+# assign, author, comment, invitation, manual, mention, review_requested, security_alert, state_change, subscribed, team_mention, ci_activity
+# NotificationSubjectTypes:
+# CheckSuite, Commit, Discussion, Issue, PullRequest, Release, RepositoryVulnerabilityAlert, ...
+
 help() {
     # IMPORTANT: keep it synchronized with the README, but without the Examples
     # Leave one line blank at the beginning and end, and two between sections. This looks cleaner.
@@ -84,17 +94,18 @@ get_notifs() {
         local_page_size=$num_notifications
     fi
     printf >&2 "." # "marching ants" because sometimes this takes a bit.
-    # timefmt must use the reference time Mon Jan 2 15:04:05 MST 2006 to format a given time
-    # Empty strings are colorized to keep the columns in line.
     gh api -X GET notifications --cache=20s \
         -f per_page="$local_page_size" -f all="$include_all_flag" -f participating="$only_participating_flag" -f page="$page_num" \
         --template '
     {{- range . -}}
+        {{- /* COMMENT: timefmt must use the reference time Mon Jan 2 15:04:05 MST 2006 to format a given time */ -}}
         {{- printf "%s\t%s\t%s\t" (timefmt "02/Jan 15:04" .updated_at | color "gray+h") .subject.type .subject.title -}}
         {{- printf "%s%s%s\t" (.repository.owner.login | color "cyan+h") ("/" | color "gray+h") (.repository.name | color "cyan+hb") -}}
         {{- if .subject.url -}}{{- printf "%s\t" .subject.url -}}{{- end -}}
-        {{- if .unread -}} {{- printf "%s\n" ("●" | color "magenta") -}}
-        {{- else -}} {{- printf "%s\n" (" " | color "magenta") -}} {{- end -}}
+        {{- if .unread -}}{{- printf "%s\n" ("●" | color "magenta") -}}
+            {{- /* COMMENT: Empty strings are colorized to keep the columns in line. */ -}}
+            {{- else -}}{{- printf "%s\n" (" " | color "magenta") -}}
+        {{- end -}}
     {{- end -}}'
 }
 
@@ -111,7 +122,9 @@ print_notifs() {
         fi
         new_notifs=$(
             echo "$page" | while IFS=$'\t' read -r timefmt type title repo url unread; do
-                if grep -q "Release" <<<"$type"; then
+                if grep -q "Commit" <<<"$type"; then
+                    number=$(basename "$url" | head -c 7)
+                elif grep -q "Release" <<<"$type"; then
                     release_info=()
                     while IFS='' read -r line; do release_info+=("$line"); done < <(gh api --cache=20s "$url" --jq '.tag_name, .prerelease')
                     number="${release_info[0]}"
@@ -158,13 +171,12 @@ select_notif() {
     local notifs open_notification_browser preview_notification selection key repo type num
     notifs="$(filtered_notifs)"
     [ -n "$notifs" ] || exit 0
-    open_notification_browser='if grep -qE "Issue|PullRequest" <<<{4}; then gh issue view {5} -wR {3}; elif grep -q "[Rr]elease" <<<{4}; then gh release view {5} -wR {3}; else gh repo view -w {3}; fi'
+    open_notification_browser='if grep -q CheckSuite <<<{4}; then open https://github.com/{3}/actions ; elif grep -q Commit <<<{4}; then gh browse {5} -R {3} ; elif grep -q Discussion <<<{4}; then open https://github.com/{3}/discussions ; elif grep -qE "Issue|PullRequest" <<<{4}; then gh issue view {5} -wR {3}; elif grep -q "[Rr]elease" <<<{4}; then gh release view {5} -wR {3}; else gh repo view -w {3}; fi'
     preview_notification='echo \[{1} {2} - {4}\] ;if grep -q Issue <<<{4}; then gh issue view {5} -R {3} --comments; elif grep -q PullRequest <<<\"{4}\"; then gh pr view {5} -R {3} --comments; elif grep -q "[Rr]elease" <<<{4}; then gh release view {5} -R {3}; else echo "Notification preview for {4} is not supported."; fi'
-    # Enable terminal-style output even when the output is redirected.
-    export GH_FORCE_TTY=100%
+
     # See the man page (man fzf) for an explanation of the arguments.
-    selection=$(fzf <<<"$notifs" --ansi --no-multi --reverse --info=inline \
-        --margin 2,1%,2,1% --pointer='▶' \
+    selection=$(fzf <<<"$notifs" --ansi --no-multi \
+        --reverse --info=inline --pointer='▶' \
         --border horizontal --color "border:#778899" \
         --header $'? - Toggle Help\n\n' --color 'header:italic:dim' \
         --header-first --bind "change:first" \
@@ -179,8 +191,6 @@ select_notif() {
     read -r key _ _ repo type num _ <<<"$selection"
     [[ -n "$key" ]] && case "$key" in
     enter)
-        # Disable the gh pager
-        export GH_PAGER="cat"
         if grep -q "Issue" <<<"$type"; then
             gh issue view "$num" -R "$repo" --comments
         elif grep -q "PullRequest" <<<"$type"; then


### PR DESCRIPTION
### Description
- Allow `CheckSuite, Commit and Discussion` to also be opened with the browser hotkey
- `Commit` types get the commit sha from the `REST API` notification call

```json
  {
    "id": "4755318386",
    "unread": false,
    "reason": "author",
    "updated_at": "2022-11-04T06:59:39Z",
    "last_read_at": "2022-11-04T07:04:36Z",
    "subject": {
      "title": "use format suitable for file names",
      "url": "https://api.github.com/repos/LangLangBart/ImagePool/commits/6846c9d5257e7073588e66c92fc05278f4c39d9f",
      "latest_comment_url": "https://api.github.com/repos/LangLangBart/ImagePool/comments/88843966",
      "type": "Commit"
    },
    "repository": {
      "id": 532566962,
      "node_id": "R_kgDOH75Tsg",
      "name": "ImagePool",
      "full_name": "LangLangBart/ImagePool",
      "private": false,
      "owner": {
        "login": "LangLangBart",
```

<img src="https://user-images.githubusercontent.com/92653266/199927884-a4cddef1-6022-4cb8-a28c-51a00b680a37.png" width="600">

  - `CheckSuite` and `Discussion` types don't retrun much useable information and will only open on the correct tab of the repo (see #29 for more details).

```zsh
# CheckSuite
open https://github.com/{3}/actions
# Discussion
open https://github.com/{3}/discussions
```


#### Additionally
- the `gh` environment variables (`GH_FORCE_TTY` and `GH_PAGER`) have been moved to the top, due to a recent change released with [v2.19.0](https://github.com/cli/cli/releases/tag/v2.19.0) the repo name color appeared white in the list
  - see [cli/cli/pull/6510](https://github.com/cli/cli/pull/6510) for more details
  - the colors should now look the same as in the previous version [v2.18.1](https://github.com/cli/cli/releases/tag/v2.18.1)
  - the `GH_PAGER` has been moved up to have the two environment variables close together and not spread all over the document
- the `--margin 2,1%,2,1%` flag from the `fzf` has been removed,
- added some notes at the beginning of the document about NotificationSubjectTypes and NotificationReason as information
  - these were copied from [manosim/gitify](https://github.com/manosim/gitify/blob/c3683dcfd84afc74fd391b2b17ae7b36dfe779a7/src/typesGithub.ts)


