### PR TITLE
title for fzf window

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -64,7 +64,6 @@ filter_string=''
 # UTC time ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
 # https://docs.github.com/en/rest/overview/resources-in-the-rest-api#timezones
 timestamp=$(date +"%Y-%m-%dT%H:%M:%S%z")
-user_name=$(gh api graphql --cache 1h --raw-field query='{viewer{login}}' --jq '.data.viewer.login')
 
 while getopts 'e:f:n:pawhsr' flag; do
     case "${flag}" in
@@ -172,16 +171,16 @@ select_notif() {
     selection=$(
         fzf <<<"$notifs" --ansi --no-multi \
             --reverse --info=inline --pointer='▶' \
-            --border bold --color "border:#778899" \
-            --border-label " ${user_name}'s GitHub Notifications (? help • esc quit) " --border-label-pos 3 \
-            --color=label:bold:255 \
+            --border rounded --color 'border:255,label:244:bold' \
+            --border-label " Notifications (? help • esc quit) " --border-label-pos 3 \
+            --preview "$preview_notification" \
+            --preview-label " Preview " --preview-label-pos 3 \
+            --preview-window wrap:"$preview_window_visibility":50%:right:border \
             --no-separator --header $'\n' \
             --header-first --bind "change:first" \
             --bind "?:toggle-preview+change-preview:printf \"Help\n%s\" \"$(help)\"" \
             --bind "ctrl-b:execute-silent:$open_notification_browser" \
             --bind "tab:toggle-preview+change-preview:$preview_notification" \
-            --preview-window wrap:"$preview_window_visibility":50%:right:border-left \
-            --preview "$preview_notification" \
             --expect "enter,ctrl-r,ctrl-x" | tr '\n' ' '
     )
 

--- a/gh-notify
+++ b/gh-notify
@@ -166,7 +166,7 @@ select_notif() {
     notifs="$(print_notifs)"
     [ -n "$notifs" ] || exit 0
     open_notification_browser='if grep -q CheckSuite <<<{4}; then open https://github.com/{3}/actions ; elif grep -q Commit <<<{4}; then gh browse {5} -R {3} ; elif grep -q Discussion <<<{4}; then open https://github.com/{3}/discussions ; elif grep -qE "Issue|PullRequest" <<<{4}; then gh issue view {5} -wR {3}; elif grep -q "[Rr]elease" <<<{4}; then gh release view {5} -wR {3}; else gh repo view -w {3}; fi'
-    preview_notification='echo \[{1} {2} - {4}\] ;if grep -q Issue <<<{4}; then gh issue view {5} -R {3} --comments; elif grep -q PullRequest <<<\"{4}\"; then gh pr view {5} -R {3} --comments; elif grep -q "[Rr]elease" <<<{4}; then gh release view {5} -R {3}; else echo "Notification preview for {4} is not supported."; fi'
+    preview_notification=$'echo \'\n[{1} {2} - {4}]\' ;if grep -q Issue <<<{4}; then gh issue view {5} -R {3} --comments; elif grep -q PullRequest <<<\"{4}\"; then gh pr view {5} -R {3} --comments; elif grep -q "[Rr]elease" <<<{4}; then gh release view {5} -R {3}; else echo "Notification preview for {4} is not supported."; fi'
 
     # See the man page (man fzf) for an explanation of the arguments.
     selection=$(

--- a/gh-notify
+++ b/gh-notify
@@ -64,6 +64,7 @@ filter_string=''
 # UTC time ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
 # https://docs.github.com/en/rest/overview/resources-in-the-rest-api#timezones
 timestamp=$(date +"%Y-%m-%dT%H:%M:%S%z")
+user_name=$(gh api graphql --cache 1h --raw-field query='{viewer{login}}' --jq '.data.viewer.login')
 
 while getopts 'e:f:n:pawhsr' flag; do
     case "${flag}" in
@@ -153,20 +154,7 @@ print_notifs() {
     done
     # clear the dots we printed
     echo >&2 -e "\r\033[K"
-    # the different pages frequently come back with different
-    # column widths.
-    # If we insert a tab before the notification type
-    # and recolumnize on that everything works out.
-    echo "$all_notifs" |
-        sed -e "s/ Issue / \tIssue /" \
-            -e "s/ PullRequest / \tPullRequest /" \
-            -e "s/ Commit / \tCommit /" \
-            -e "s/ Release / \tRelease /" |
-        column -t -s $'\t'
-}
-
-filtered_notifs() {
-    print_notifs | grep -v "$exclusion_string" | grep "$filter_string"
+    echo "$all_notifs" | grep -v "$exclusion_string" | grep "$filter_string" | column -t -s $'\t'
 }
 
 mark_read() {
@@ -175,23 +163,27 @@ mark_read() {
 
 select_notif() {
     local notifs open_notification_browser preview_notification selection key repo type num
-    notifs="$(filtered_notifs)"
+    notifs="$(print_notifs)"
     [ -n "$notifs" ] || exit 0
     open_notification_browser='if grep -q CheckSuite <<<{4}; then open https://github.com/{3}/actions ; elif grep -q Commit <<<{4}; then gh browse {5} -R {3} ; elif grep -q Discussion <<<{4}; then open https://github.com/{3}/discussions ; elif grep -qE "Issue|PullRequest" <<<{4}; then gh issue view {5} -wR {3}; elif grep -q "[Rr]elease" <<<{4}; then gh release view {5} -wR {3}; else gh repo view -w {3}; fi'
     preview_notification='echo \[{1} {2} - {4}\] ;if grep -q Issue <<<{4}; then gh issue view {5} -R {3} --comments; elif grep -q PullRequest <<<\"{4}\"; then gh pr view {5} -R {3} --comments; elif grep -q "[Rr]elease" <<<{4}; then gh release view {5} -R {3}; else echo "Notification preview for {4} is not supported."; fi'
 
     # See the man page (man fzf) for an explanation of the arguments.
-    selection=$(fzf <<<"$notifs" --ansi --no-multi \
-        --reverse --info=inline --pointer='▶' \
-        --border horizontal --color "border:#778899" \
-        --header $'? - Toggle Help\n\n' --color 'header:italic:dim' \
-        --header-first --bind "change:first" \
-        --bind "?:toggle-preview+change-preview:printf \"Help\n%s\" \"$(help)\"" \
-        --bind "ctrl-b:execute-silent:$open_notification_browser" \
-        --bind "tab:toggle-preview+change-preview:$preview_notification" \
-        --preview-window wrap:"$preview_window_visibility":50%:right:border-left \
-        --preview "$preview_notification" \
-        --expect "enter,ctrl-r,ctrl-x" | tr '\n' ' ')
+    selection=$(
+        fzf <<<"$notifs" --ansi --no-multi \
+            --reverse --info=inline --pointer='▶' \
+            --border bold --color "border:#778899" \
+            --border-label " ${user_name}'s GitHub Notifications (? help • esc quit) " --border-label-pos 3 \
+            --color=label:bold:255 \
+            --no-separator --header $'\n' \
+            --header-first --bind "change:first" \
+            --bind "?:toggle-preview+change-preview:printf \"Help\n%s\" \"$(help)\"" \
+            --bind "ctrl-b:execute-silent:$open_notification_browser" \
+            --bind "tab:toggle-preview+change-preview:$preview_notification" \
+            --preview-window wrap:"$preview_window_visibility":50%:right:border-left \
+            --preview "$preview_notification" \
+            --expect "enter,ctrl-r,ctrl-x" | tr '\n' ' '
+    )
 
     # Hotkey actions that close fzf are defined below
     read -r key _ _ repo type num _ <<<"$selection"
@@ -234,5 +226,5 @@ if [[ $print_static_flag == "false" ]]; then
     fi
     select_notif
 else
-    filtered_notifs
+    print_notifs
 fi


### PR DESCRIPTION
### Description
- `fzf` has added the ability to add titles to the border with version [0.35.0](https://github.com/junegunn/fzf/releases/tag/0.35.0).


<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/e01ff455d463d51bb5bfa2bfcc2fa54026759207/storage/2022-11-15_14-00-23_fzf_title_update.png" width="800">

Related tickets:
- https://github.com/junegunn/fzf/issues/3022
- https://github.com/junegunn/fzf/issues/3029

---

hot or a flop?
- :green_heart: a title makes it look more advanced
- :broken_heart: user must have at least `fzf 0.35.0`

---

I think it looks better with titles, reminds me of my favorite git browser: [extrawurst/gitui](https://github.com/extrawurst/gitui)

<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/f83d54d58d53057a919f7aae8089f46b96cf4d27/storage/2022-11-15_11-29-16_gitui.png" width="600">
