### PR TITLE
follow up on issue #32

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -129,13 +129,15 @@ print_notifs() {
                 if grep -q "Commit" <<<"$type"; then
                     number=$(basename "$url" | head -c 7)
                 elif grep -q "Release" <<<"$type"; then
-                    if grep -q "^http" <<<"$url"; then
+                    if grep -q "^http" <<<"$url" && gh api --cache 20s --header "X-GitHub-Api-Version:$GH_REST_API_VERSION" --method GET "$url" --silent 2>/dev/null; then
+                        #  URL works
                         release_info=()
-                        while IFS='' read -r line; do release_info+=("$line"); done < <(gh api --header "X-GitHub-Api-Version:$GH_REST_API_VERSION" --method GET --cache=20s "$url" --jq '.tag_name, .prerelease')
+                        while IFS='' read -r line; do release_info+=("$line"); done < <(gh api --cache 20s --header "X-GitHub-Api-Version:$GH_REST_API_VERSION" --method GET "$url" --jq '.tag_name, .prerelease')
                         number="${release_info[0]}"
                         "${release_info[1]}" && type="Pre-release"
                     else
-                        number="Tag number not present"
+                        #  URL does not work, no need to show the notification
+                        continue
                     fi
                 else
                     # gh api calls cost time, try to avoid them as much as possible


### PR DESCRIPTION
### Description
- Problem #32 was reopened, a `URL` is returned, but for some reason its contents could not be accessed
- the problem could be reproduced after subscribing to `jetpack-io/devbox` for a while, they have a weekly release schedule


### Solution
- Add an URL check for release types, if successful continue normally, otherwise skip the message with [continue](https://tldp.org/LDP/abs/html/abs-guide.html#EX28).
  - > *The break command terminates the loop (breaks out of it), while continue causes a jump to the next iteration of the loop, skipping all the remaining commands in that particular loop cycle.*

- 1st picture below the current state, 2nd picture this applied patch.

<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/3e5389df0a2da2d09e1b4052ff1605e256c04b7b/storage/2022-12-13_10-16-53_url_check.png" width="600">



