### PR TITLE
only mark notifications in fzf, as read when the hoeky was pressed

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -163,9 +163,7 @@ print_notifs() {
 
     echo "$all_notifs" | grep -v "$exclusion_string" | grep "$filter_string" | column -t -s $'\t'
 }
-mark_read() {
-    gh api --header "X-GitHub-Api-Version:$GH_REST_API_VERSION" --method PUT notifications -f last_read_at="$timestamp" -F read=true --silent
-}
+
 select_notif() {
     local notif_msg open_notification_browser preview_notification selection key repo type num
     notif_msg="$1"
@@ -173,6 +171,8 @@ select_notif() {
     diff_pager=$'if type -p delta >/dev/null; then delta --width ${FZF_PREVIEW_COLUMNS:-$COLUMNS}; else cat; fi'
     open_notification_browser='if grep -q CheckSuite <<<{4}; then open https://github.com/{3}/actions ; elif grep -q Commit <<<{4}; then gh browse {5} -R {3} ; elif grep -q Discussion <<<{4}; then open https://github.com/{3}/discussions ; elif grep -qE "Issue|PullRequest" <<<{4}; then gh issue view {5} -wR {3}; elif grep -q "[Rr]elease" <<<{4}; then gh release view {5} -wR {3}; else gh repo view -w {3}; fi'
     preview_notification='echo \[{1} {2} - {4}\] ;if grep -q Issue <<<{4}; then gh issue view {5} -R {3} --comments; elif grep -q PullRequest <<<\"{4}\"; then gh pr view {5} -R {3} --comments; elif grep -q "[Rr]elease" <<<{4}; then gh release view {5} -R {3}; else echo "Notification preview for {4} is not supported."; fi'
+    # If this were passed as a function to fzf, it would be called immediately when fzf is called, in spite of the fact that the assigned hotkey was not triggered.
+    fzf_mark_read="gh api --header X-GitHub-Api-Version:$GH_REST_API_VERSION --method PUT notifications -f last_read_at=$timestamp -F read=true --silent"
 
     # See the man page (man fzf) for an explanation of the arguments.
     # The key combination ctrl-m is a synonym for enter,
@@ -186,7 +186,7 @@ select_notif() {
         --bind "ctrl-b:execute-silent:$open_notification_browser" \
         --bind "ctrl-d:toggle-preview+change-preview:if grep -q PullRequest <<<{4}; then gh pr diff {5} -R {3} | $diff_pager; else $preview_notification; fi" \
         --bind "ctrl-p:toggle-preview+change-preview:if grep -q PullRequest <<<{4}; then gh pr diff {5} --patch -R {3} | $diff_pager; else  $preview_notification; fi" \
-        --bind "ctrl-r:+execute-silent($(mark_read))+reload:$reload_arguments" \
+        --bind "ctrl-r:+execute-silent($fzf_mark_read)+reload:$reload_arguments" \
         --bind "tab:toggle-preview+change-preview:$preview_notification" \
         --preview-window wrap:"$preview_window_visibility":50%:right:border-left \
         --preview "$preview_notification" \
@@ -218,7 +218,7 @@ select_notif() {
 }
 
 if [[ $mark_read_flag == "true" ]]; then
-    mark_read
+    gh api --header "X-GitHub-Api-Version:$GH_REST_API_VERSION" --method PUT notifications -f last_read_at="$timestamp" -F read=true --silent
     exit 0
 fi
 


### PR DESCRIPTION
## Description
- #38 introduced an unwanted effect
- the function to mark notifications as read is triggered immediately when fzf is called, even though the assigned hotkey has not been triggered.

## to reproduce
- have at least one unread notification
- run `gh notify`, the notification will be displayed correctly, close fzf
- run `gh notofy` again, the unread notification is no longer displayed, although the hotkey was not triggered

### debug
The order in which the commands are executed can be better observed if you enable [debugging](https://tldp.org/LDP/Bash-Beginners-Guide/html/Bash-Beginners-Guide.html#sect_02_03) for the script, for example with `set -x`


```sh
# debug
# mark_read was called at the third level of a subshell
# ...
++ grep -v XXX_BOGUS_STRING_THAT_SHOULD_NOT_EXIST_XXX
++ grep ''
++ column -t -s '	'
+ notifs='28/Dec 02:39  LangLangBart/boonGUI  Release v2.6.6 ●  boonGUI v2.6.6'
+ [[ -z 28/Dec 02:39  LangLangBart/boonGUI  Release v2.6.6 ●  boonGUI v2.6.6 ]]
+ [[ false == \f\a\l\s\e ]]
+ type -p fzf
+ select_notif '28/Dec 02:39  LangLangBart/boonGUI  Release v2.6.6 ●  boonGUI v2.6.6'
+ local notif_msg open_notification_browser preview_notification selection key repo type num
+ notif_msg='28/Dec 02:39  LangLangBart/boonGUI  Release v2.6.6 ●  boonGUI v2.6.6'
+ diff_pager='if type -p delta >/dev/null; then delta --width ${FZF_PREVIEW_COLUMNS:-$COLUMNS}; else cat; fi'
+ open_notification_browser='if grep -q CheckSuite <<<{4}; then open https://github.com/{3}/actions ; elif grep -q Commit <<<{4}; then gh browse {5} -R {3} ; elif grep -q Discussion <<<{4}; then open https://github.com/{3}/discussions ; elif grep -qE "Issue|PullRequest" <<<{4}; then gh issue view {5} -wR {3}; elif grep -q "[Rr]elease" <<<{4}; then gh release view {5} -wR {3}; else gh repo view -w {3}; fi'
+ preview_notification='echo \[{1} {2} - {4}\] ;if grep -q Issue <<<{4}; then gh issue view {5} -R {3} --comments; elif grep -q PullRequest <<<\"{4}\"; then gh pr view {5} -R {3} --comments; elif grep -q "[Rr]elease" <<<{4}; then gh release view {5} -R {3}; else echo "Notification preview for {4} is not supported."; fi'
++ tr '\n' ' '
+++ help
+++ cat
+++ mark_read
+++ gh api --header X-GitHub-Api-Version:2022-11-28 --method PUT notifications -f last_read_at=2022-12-28T04:33:34+0100 -F read=true --silent
++ fzf --ansi --no-multi --reverse --info=inline $'--pointer=?\226?' --border horizontal --color border:#778899 --header '? - Toggle Help
```

## solution
- transfrom the function into an alias and pass it to fzf
