### PR TITLE
Fix for default shells other than Bash

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -185,7 +185,7 @@ select_notif() {
     # See the man page (man fzf) for an explanation of the arguments.
     # The key combination ctrl-m is a synonym for enter,
     # therefore the key to mark notifications as read shall not be ctrl-m.
-    selection=$(fzf <<<"$notif_msg" --ansi --no-multi \
+    selection=$(SHELL="bash" fzf <<<"$notif_msg" --ansi --no-multi \
         --reverse --info=inline --pointer='▶' \
         --border horizontal --color "border:#778899" \
         --header $'? - Toggle Help\n\n' --color 'header:italic:dim' \


### PR DESCRIPTION
I use Fish [1] as my default shell and this causes the preview window to
fail for gh commands (Fish uses bits of non-POSIX syntax).

This is because Fzf uses the default shell (set in the `$SHELL`
environment variable) to run the commands passed as arguments to bind.
Since the script is written in Bash, Bash is already a requirement.
Furthermore, the actions on binding are also written with Bash in mind,
so it makes sense in my opinion to instruct Fzf to use this shell.

[1] https://fishshell.com/
