### PR TITLE
feat: open correct discussion in browser

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -112,10 +112,14 @@ get_notifs() {
         -f per_page="$local_page_size" -f all="$include_all_flag" -f participating="$only_participating_flag" -f page="$page_num" \
         --template '
     {{- range . -}}
+        {{- /* Comment: Hidden data points without color codes used in GraphQL query */ -}}
+        {{- printf "%s\t%s\t" (timefmt "2006-01" .updated_at) .repository.full_name -}}
         {{- /* COMMENT: timefmt must use the reference time Mon Jan 2 15:04:05 MST 2006 to format a given time */ -}}
         {{- printf "%s\t%s\t%s\t" (timefmt "02/Jan 15:04" .updated_at | color "gray+h") .subject.type .subject.title -}}
         {{- printf "%s%s%s\t" (.repository.owner.login | color "cyan+h") ("/" | color "gray+h") (.repository.name | color "cyan+hb") -}}
-        {{- if .subject.url -}}{{- printf "%s\t" .subject.url -}}{{- end -}}
+        {{- if .subject.url -}}{{- printf "%s\t" .subject.url -}}
+            {{- else -}}{{- printf " \t" -}}
+        {{- end -}}
         {{- if .unread -}}{{- printf "%s\n" ("●" | color "magenta") -}}
             {{- /* COMMENT: Empty strings are colorized to keep the columns in line. */ -}}
             {{- else -}}{{- printf "%s\n" (" " | color "magenta") -}}
@@ -124,7 +128,7 @@ get_notifs() {
 }
 
 print_notifs() {
-    local timefmt type title repo url unread number
+    local hidden_updated_at hidden_repository_full_name timefmt type title repo url unread number graphql_query_discussion
     all_notifs=""
     page_num=1
     while true; do
@@ -135,8 +139,12 @@ print_notifs() {
             page_num=$((page_num + 1))
         fi
         new_notifs=$(
-            echo "$page" | while IFS=$'\t' read -r timefmt type title repo url unread; do
-                if grep -q "Commit" <<<"$type"; then
+            echo "$page" | while IFS=$'\t' read -r hidden_updated_at hidden_repository_full_name timefmt type title repo url unread; do
+                if grep -q "Discussion" <<<"$type"; then
+                    graphql_query_discussion=$'query ($filter: String!) { search(query: $filter, type: DISCUSSION, first: 1) { nodes { ... on Discussion { number }}}}'
+                    # https://docs.github.com/en/search-github/searching-on-github/searching-discussions
+                    number=$(gh api graphql --cache=100h --raw-field filter="$title in:title updated:>=$hidden_updated_at repo:$hidden_repository_full_name" --raw-field query="$graphql_query_discussion" --jq '.data.search.nodes | .[].number')
+                elif grep -q "Commit" <<<"$type"; then
                     number=$(basename "$url" | head -c 7)
                 elif grep -q "Release" <<<"$type"; then
                     if grep -q "^http" <<<"$url" && gh api --cache 20s --header "X-GitHub-Api-Version:$GH_REST_API_VERSION" --method GET "$url" --silent 2>/dev/null; then
@@ -172,11 +180,11 @@ print_notifs() {
 }
 
 select_notif() {
-    local notif_msg open_notification_browser preview_notification selection key repo type num
+    local notif_msg diff_pager open_notification_browser preview_notification selection key repo type num
     notif_msg="$1"
     # https://dandavison.github.io/delta
     diff_pager=$'if type -p delta >/dev/null; then delta --width ${FZF_PREVIEW_COLUMNS:-$COLUMNS}; else cat; fi'
-    open_notification_browser='if grep -q CheckSuite <<<{4}; then open https://github.com/{3}/actions ; elif grep -q Commit <<<{4}; then gh browse {5} -R {3} ; elif grep -q Discussion <<<{4}; then open https://github.com/{3}/discussions ; elif grep -qE "Issue|PullRequest" <<<{4}; then gh issue view {5} -wR {3}; elif grep -q "[Rr]elease" <<<{4}; then gh release view {5} -wR {3}; else gh repo view -w {3}; fi'
+    open_notification_browser='if grep -q CheckSuite <<<{4}; then open https://github.com/{3}/actions ; elif grep -q Commit <<<{4}; then gh browse {5} -R {3} ; elif grep -q Discussion <<<{4}; then open https://github.com/{3}/discussions/{5} ; elif grep -qE "Issue|PullRequest" <<<{4}; then gh issue view {5} -wR {3}; elif grep -q "[Rr]elease" <<<{4}; then gh release view {5} -wR {3}; else gh repo view -w {3}; fi'
     preview_notification='echo \[{1} {2} - {4}\] ;if grep -q Issue <<<{4}; then gh issue view {5} -R {3} --comments; elif grep -q PullRequest <<<\"{4}\"; then gh pr view {5} -R {3} --comments; elif grep -q "[Rr]elease" <<<{4}; then gh release view {5} -R {3}; else echo "Notification preview for {4} is not supported."; fi'
     # If this were passed as a function to fzf, it would be called immediately when fzf is called, in spite of the fact that the assigned hotkey was not triggered.
     fzf_mark_read="gh api --header X-GitHub-Api-Version:$GH_REST_API_VERSION --method PUT notifications -f last_read_at=$timestamp -F read=true --silent"


### PR DESCRIPTION
### Description
- fix #46
  - ref: #29
  - the discussion number is searched through a `GraphQL` query and cached for `100h`, the long cache time is set to take into account the concerns from the referenced pull request previously
- if GitHub provides infos about discussions through its [Notifications REST API](https://docs.github.com/en/rest/activity/notifications) or allows to pull the infos via a `GraphQL` query then it would make this workaround obsolete
  - currently there seems to be no plans: [GitHub public roadmap](https://github.com/orgs/github/projects/4247/views/1?filterQuery=)


---

- I tested it the last few days, and it worked for all my discussion threads, and it was no slower than usual.
