### PR TITLE
style: update prompt and header color

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -195,10 +195,10 @@ select_notif() {
     selection=$(
         SHELL="bash" fzf <<<"$notif_msg" \
             --ansi --no-multi \
-            --reverse --info=inline --pointer='▶' \
-            --border horizontal --color "border:#778899" \
-            --header "? Help · esc Quit" --color 'header:green:italic:dim' \
-            --prompt "GitHub Notifications > " \
+            --reverse --info=inline --pointer="▶" \
+            --border horizontal --color "border:dim" \
+            --header "? Help · esc Quit" --color "header:green:italic:dim" \
+            --prompt "GitHub Notifications > " --color "prompt:80,info:40"\
             --bind "change:first" \
             --bind "?:toggle-preview+change-preview:echo -e '$HELP_TEXT'" \
             --bind "ctrl-b:execute-silent:$open_notification_browser" \
@@ -206,7 +206,7 @@ select_notif() {
             --bind "ctrl-p:toggle-preview+change-preview:if grep -q PullRequest <<<{4}; then gh pr diff {5} --patch -R {3} | $diff_pager; else  $preview_notification; fi" \
             --bind "ctrl-r:+execute-silent($fzf_mark_read)+reload:$reload_arguments" \
             --bind "tab:toggle-preview+change-preview:$preview_notification" \
-            --bind 'btab:change-preview-window(75%:nohidden|75%:down:nohidden:border-top|nohidden)' \
+            --bind "btab:change-preview-window(75%:nohidden|75%:down:nohidden:border-top|nohidden)" \
             --preview-window wrap:"$preview_window_visibility":50%:right:border-left \
             --preview "$preview_notification" \
             --expect "enter,esc,ctrl-x" | tr '\n' ' '


### PR DESCRIPTION
### description
- color `prompt` in cyan and `info` in green to restrict the use of colors, which looks more consistent on the UI and more like in the image from #45
