### PR TITLE
feat: mark individual notifications as read

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -51,7 +51,7 @@ ${WHITE_BOLD}Key Bindings fzf${NC}
   ${GREEN}ctrl+p   ${NC}  view diff in patch format
   ${GREEN}ctrl+r   ${NC}  mark all displayed notifications as read and reload
   ${GREEN}ctrl+t   ${NC}  mark notification as read and reload
-  ${GREEN}ctrl+x   ${NC}  write a comment with the editor, mark the notification as read and quit
+  ${GREEN}ctrl+x   ${NC}  write a comment with the editor and quit
   ${GREEN}esc      ${NC}  quit
 
 ${WHITE_BOLD}Example${NC}
@@ -119,7 +119,6 @@ get_notifs() {
     fi
     printf >&2 "." # "marching ants" because sometimes this takes a bit.
     # Use '-F/--field' to pass a variable that is a number, Boolean, or null. Use '-f/--raw-field' for other variables.
-    # shellcheck disable=SC2016
     gh api --header "$GH_REST_API_VERSION" --method GET notifications --cache=0s \
         --field per_page="$local_page_size" --field page="$page_num" \
         --field participating="$only_participating_flag" --field all="$include_all_flag" \
@@ -160,7 +159,7 @@ print_notifs() {
     all_notifs=""
     page_num=1
     while true; do
-        page=$(get_notifs $page_num)
+        page=$(get_notifs $page_num) || { echo "Failed to get notifications." >&2 && exit 1; }
         if [ "$page" == "" ]; then
             break
         else
@@ -171,7 +170,7 @@ print_notifs() {
                 if grep -q "Discussion" <<<"$type"; then
                     graphql_query_discussion=$'query ($filter: String!) { search(query: $filter, type: DISCUSSION, first: 1) { nodes { ... on Discussion { number }}}}'
                     # https://docs.github.com/en/search-github/searching-on-github/searching-discussions
-                    number=$(gh api graphql --cache=100h --raw-field filter="$title in:title updated:>=$hidden_updated_at repo:$hidden_repository_full_name" --raw-field query="$graphql_query_discussion" --jq '.data.search.nodes | .[].number')
+                    number=$(gh api graphql --cache=100h --raw-field filter="$title in:title updated:>=$hidden_updated_at repo:$hidden_repository_full_name" --raw-field query="$graphql_query_discussion" --jq '.data.search.nodes | .[].number') || { echo "Failed GraphQL discussion query." >&2 && exit 1; }
                 elif ! grep -q "^null" <<<"$url"; then
                     if grep -q "Commit" <<<"$type"; then
                         number=$(basename "$url" | head -c 7)
@@ -192,7 +191,7 @@ print_notifs() {
 
                 printf "\n%s\t%s\t%s\t%s\t%s\t%s\t%s ${GREEN}%s${NC} %s\t%s\n" "$iso8601" "$thread_id" "$thread_state" "$comment_url" "$timefmt" "$repo" "$type" "$number" "$unread_symbol" "$title"
             done
-        )
+        ) || exit 1
         all_notifs="$all_notifs$new_notifs"
         # this is going to be a bit funky.
         # if you specify a number larger than 100
@@ -241,8 +240,8 @@ select_notif() {
             --bind "ctrl-b:execute-silent:$open_notification_browser" \
             --bind "ctrl-d:toggle-preview+change-preview:if grep -q PullRequest <<<{8}; then gh pr diff {9} -R {7} | $diff_pager; else $preview_notification; fi" \
             --bind "ctrl-p:toggle-preview+change-preview:if grep -q PullRequest <<<{8}; then gh pr diff {9} --patch -R {7} | $diff_pager; else  $preview_notification; fi" \
-            --bind "ctrl-r:execute-silent($mark_all_read)+reload:$reload_arguments" \
-            --bind "ctrl-t:execute-silent($mark_individual_read)+reload:$reload_arguments" \
+            --bind "ctrl-r:execute-silent($mark_all_read)+reload:$reload_arguments || true" \
+            --bind "ctrl-t:execute-silent($mark_individual_read)+reload:$reload_arguments || true" \
             --bind "tab:toggle-preview+change-preview:$preview_notification" \
             --bind "btab:change-preview-window(75%:nohidden|75%:down:nohidden:border-top|nohidden)" \
             --preview-window wrap:"$preview_window_visibility":50%:right:border-left \
@@ -278,20 +277,16 @@ select_notif() {
     esac
 }
 
-# quick check if you can connect to the GitHub API
-if ! gh api --silent --header "$GH_REST_API_VERSION" zen; then
-    exit 1
-fi
 if [[ $mark_read_flag == "true" ]]; then
-    gh api --header "$GH_REST_API_VERSION" --method PUT notifications --raw-field last_read_at="$timestamp" --field read=true --silent
+    gh api --header "$GH_REST_API_VERSION" --method PUT notifications --raw-field last_read_at="$timestamp" --field read=true --silent || { echo "Failed to mark notifications as read." >&2 && exit 1; }
     exit 0
 fi
 
 notifs="$(print_notifs)"
 if [[ -z "$notifs" ]]; then
-    # TODO: exit fzf when the list is empty.
+    # TODO: exit fzf when the list is empty and remove no-break spaces.
     # 4x NO-BREAK SPACE when fzf is reloaded and the list is empty,
-    # this message is displayed and the first three elements are hidden.
+    # this message is displayed and the first elements are hidden.
     echo "        All caught up!"
     exit 0
 elif [[ $print_static_flag == "false" ]]; then

--- a/gh-notify
+++ b/gh-notify
@@ -175,12 +175,11 @@ print_notifs() {
                     if grep -q "Commit" <<<"$type"; then
                         number=$(basename "$url" | head -c 7)
                     elif grep -q "Release" <<<"$type"; then
-                        if gh api --cache=20s --header "$GH_REST_API_VERSION" --method GET "$url" --silent 2>/dev/null; then
-                            release_info=()
-                            while IFS='' read -r line; do release_info+=("$line"); done < <(gh api --cache=20s --header "$GH_REST_API_VERSION" --method GET "$url" --jq '.tag_name, .prerelease')
-                            number="${release_info[0]}"
-                            "${release_info[1]}" && type="Pre-release"
+                        # directly read the output into number and prerelease variables
+                        if IFS=$'\t' read -r number prerelease < <(gh api --cache=100h --header "$GH_REST_API_VERSION" --method GET "$url" --jq '[.tag_name, .prerelease] | @tsv'); then
+                            "$prerelease" && type="Pre-release"
                         else
+                            # it may happen that URLs are retrieved but are already dead and therefore skipped
                             continue
                         fi
                     else

--- a/gh-notify
+++ b/gh-notify
@@ -2,7 +2,7 @@
 set -eo pipefail
 
 # https://docs.github.com/en/rest/overview/api-versions
-GH_REST_API_VERSION="2022-11-28"
+GH_REST_API_VERSION="X-GitHub-Api-Version:2022-11-28"
 # The minimum fzf version that the user needs to run all interactive commands.
 MIN_FZF_VERSION="0.29.0"
 
@@ -17,6 +17,7 @@ export GH_PAGER="cat"
 # CheckSuite, Commit, Discussion, Issue, PullRequest, Release, RepositoryVulnerabilityAlert, ...
 
 GREEN='\033[0;32m'
+MAGENTA='\033[0;35m'
 NC='\033[0m'
 WHITE_BOLD='\033[1m'
 
@@ -115,29 +116,27 @@ get_notifs() {
     fi
     printf >&2 "." # "marching ants" because sometimes this takes a bit.
     # Use '-F/--field' to pass a variable that is a number, Boolean, or null. Use '-f/--raw-field' for other variables.
-    gh api --header "X-GitHub-Api-Version:$GH_REST_API_VERSION" --method GET notifications --cache=0s \
+    # shellcheck disable=SC2016
+    gh api --header "$GH_REST_API_VERSION" --method GET notifications --cache=0s \
         --field per_page="$local_page_size" --field page="$page_num" \
         --field participating="$only_participating_flag" --field all="$include_all_flag" \
         --template '
     {{- range . -}}
-        {{- /* Comment: Hidden data points without color codes used in GraphQL query */ -}}
+        {{- /* COMMENT: Hidden data points without color codes used in GraphQL query */ -}}
         {{- printf "%s\t%s\t" (timefmt "2006-01" .updated_at) .repository.full_name -}}
         {{- /* COMMENT: timefmt must use the reference time Mon Jan 2 15:04:05 MST 2006 to format a given time */ -}}
-        {{- printf "%s\t%s\t%s\t%s\t" .id (timefmt "02/Jan 15:04" .updated_at | color "gray+h") .subject.type .subject.title -}}
+        {{- $thread_state := "READ" -}}
+        {{- if .unread -}}{{- $thread_state = "UNREAD" -}}{{- end -}}
+        {{- printf "%s\t%s\t%s\t" .id $thread_state (timefmt "02/Jan 15:04" .updated_at | color "gray+h") -}}
         {{- printf "%s%s%s\t" (.repository.owner.login | color "cyan+h") ("/" | color "gray+h") (.repository.name | color "cyan+hb") -}}
-        {{- if .subject.url -}}{{- printf "%s\t" .subject.url -}}
-            {{- else -}}{{- printf " \t" -}}
-        {{- end -}}
-        {{- /* COMMENT: Unicode for ● (Black Circle) */ -}}
-        {{- if .unread -}}{{- printf "%s\n" ("\u25cf" | color "magenta") -}}
-            {{- /* COMMENT: Empty strings are colorized to keep the columns in line. */ -}}
-            {{- else -}}{{- printf "%s\n" ("" | color "magenta") -}}
-        {{- end -}}
+        {{- $url := "NONE" -}}
+        {{- if .subject.url -}}{{- $url = .subject.url -}}{{- end -}}
+        {{- printf "%s\t%s\t%s\n" .subject.type $url .subject.title -}}
     {{- end -}}'
 }
 
 print_notifs() {
-    local hidden_updated_at hidden_repository_full_name thread_id thread_id_state timefmt type title repo url unread_symbol number graphql_query_discussion
+    local hidden_updated_at hidden_repository_full_name thread_id thread_state timefmt repo type url unread_symbol title number graphql_query_discussion
     all_notifs=""
     page_num=1
     while true; do
@@ -148,36 +147,34 @@ print_notifs() {
             page_num=$((page_num + 1))
         fi
         new_notifs=$(
-            echo "$page" | while IFS=$'\t' read -r hidden_updated_at hidden_repository_full_name thread_id timefmt type title repo url unread_symbol; do
+            echo "$page" | while IFS=$'\t' read -r hidden_updated_at hidden_repository_full_name thread_id thread_state timefmt repo type url title number; do
                 if grep -q "Discussion" <<<"$type"; then
                     graphql_query_discussion=$'query ($filter: String!) { search(query: $filter, type: DISCUSSION, first: 1) { nodes { ... on Discussion { number }}}}'
                     # https://docs.github.com/en/search-github/searching-on-github/searching-discussions
                     number=$(gh api graphql --cache=100h --raw-field filter="$title in:title updated:>=$hidden_updated_at repo:$hidden_repository_full_name" --raw-field query="$graphql_query_discussion" --jq '.data.search.nodes | .[].number')
-                elif grep -q "Commit" <<<"$type"; then
-                    number=$(basename "$url" | head -c 7)
-                elif grep -q "Release" <<<"$type"; then
-                    if grep -q "^http" <<<"$url" && gh api --cache=20s --header "X-GitHub-Api-Version:$GH_REST_API_VERSION" --method GET "$url" --silent 2>/dev/null; then
-                        #  URL works
-                        release_info=()
-                        while IFS='' read -r line; do release_info+=("$line"); done < <(gh api --cache=20s --header "X-GitHub-Api-Version:$GH_REST_API_VERSION" --method GET "$url" --jq '.tag_name, .prerelease')
-                        number="${release_info[0]}"
-                        "${release_info[1]}" && type="Pre-release"
+                elif ! grep -q "^NONE" <<<"$url"; then
+                    if grep -q "Commit" <<<"$type"; then
+                        number=$(basename "$url" | head -c 7)
+                    elif grep -q "Release" <<<"$type"; then
+                        if gh api --cache=20s --header "$GH_REST_API_VERSION" --method GET "$url" --silent 2>/dev/null; then
+                            release_info=()
+                            while IFS='' read -r line; do release_info+=("$line"); done < <(gh api --cache=20s --header "$GH_REST_API_VERSION" --method GET "$url" --jq '.tag_name, .prerelease')
+                            number="${release_info[0]}"
+                            "${release_info[1]}" && type="Pre-release"
+                        else
+                            continue
+                        fi
                     else
-                        #  URL does not work, no need to show the notification
-                        continue
+                        # gh api calls cost time, try to avoid them as much as possible
+                        number=${url/*\//#}
                     fi
-                else
-                    # gh api calls cost time, try to avoid them as much as possible
-                    # ${variable//search/replace} - https://wiki.bash-hackers.org/syntax/pe
-                    number=${url/*\//#}
                 fi
 
-                if [[ "$unread_symbol" =~ $'\u25cf' ]]; then
-                    thread_id_state="UNREAD"
-                else
-                    thread_id_state="READ"
-                fi
-                printf "\n%s\t%s\t%s\t%s\t%s ${GREEN}%s${NC} %s\t%s\n" "$thread_id" "$thread_id_state" "$timefmt" "$repo" "$type" "$number" "$unread_symbol" "$title"
+                unread_symbol=""
+                # Unicode for ● (Black Circle)
+                [[ "$thread_state" = "UNREAD" ]] && unread_symbol=$'\u25cf'
+
+                printf "\n%s\t%s\t%s\t%s\t%s ${GREEN}%s${NC} ${MAGENTA}%s${NC}\t%s\n" "$thread_id" "$thread_state" "$timefmt" "$repo" "$type" "$number" "$unread_symbol" "$title"
             done
         )
         all_notifs="$all_notifs$new_notifs"
@@ -202,8 +199,8 @@ select_notif() {
     open_notification_browser='if grep -q CheckSuite <<<{6}; then open https://github.com/{5}/actions ; elif grep -q Commit <<<{6}; then gh browse {7} -R {5} ; elif grep -q Discussion <<<{6}; then open https://github.com/{5}/discussions/{7} ; elif grep -qE "Issue|PullRequest" <<<{6}; then gh issue view {7} -wR {5}; elif grep -q "[Rr]elease" <<<{6}; then gh release view {7} -wR {5}; else gh repo view -w {5}; fi'
     preview_notification='echo \[{3} {4} - {6}\] ;if grep -q Issue <<<{6}; then gh issue view {7} -R {5} --comments; elif grep -q PullRequest <<<\"{6}\"; then gh pr view {7} -R {5} --comments; elif grep -q "[Rr]elease" <<<{6}; then gh release view {7} -R {5}; else echo "Notification preview for {6} is not supported."; fi'
     # If this were passed as a function to fzf, it would be called immediately when fzf is called, in spite of the fact that the assigned hotkey was not triggered.
-    mark_all_read="gh api --silent --header X-GitHub-Api-Version:$GH_REST_API_VERSION --method PUT notifications --raw-field last_read_at=$timestamp --field read=true"
-    mark_individual_read="if grep -q UNREAD <<<{2}; then gh api --silent --header X-GitHub-Api-Version:$GH_REST_API_VERSION --method PATCH notifications/threads/{1}; fi"
+    mark_all_read="gh api --silent --header $GH_REST_API_VERSION --method PUT notifications --raw-field last_read_at=$timestamp --field read=true"
+    mark_individual_read="if grep -q UNREAD <<<{2}; then gh api --silent --header $GH_REST_API_VERSION --method PATCH notifications/threads/{1}; fi"
 
     # See the man page (man fzf) for an explanation of the arguments.
     # The key combination ctrl-m is a synonym for enter,
@@ -231,7 +228,7 @@ select_notif() {
     )
 
     # actions that close fzf are defined below
-    read -r key thread_id thread_id_state _ _ repo type num _ <<<"$selection"
+    read -r key thread_id thread_state _ _ repo type num _ <<<"$selection"
     [[ -z "$type" ]] && exit 0
     case "$key" in
     enter)
@@ -245,8 +242,8 @@ select_notif() {
             echo "Notification preview for $type is not supported."
         fi
 
-        if grep -q UNREAD <<<"$thread_id_state"; then
-            gh api --silent --header X-GitHub-Api-Version:$GH_REST_API_VERSION --method PATCH notifications/threads/"$thread_id" ||
+        if grep -q UNREAD <<<"$thread_state"; then
+            gh api --silent --header $GH_REST_API_VERSION --method PATCH notifications/threads/"$thread_id" ||
                 { echo "Failed to mark notification as read." >&2 && exit 1; }
         fi
         ;;
@@ -262,7 +259,7 @@ select_notif() {
 }
 
 if [[ $mark_read_flag == "true" ]]; then
-    gh api --header "X-GitHub-Api-Version:$GH_REST_API_VERSION" --method PUT notifications --raw-field last_read_at="$timestamp" --field read=true --silent
+    gh api --header "$GH_REST_API_VERSION" --method PUT notifications --raw-field last_read_at="$timestamp" --field read=true --silent
     exit 0
 fi
 
@@ -284,7 +281,8 @@ elif [[ $print_static_flag == "false" ]]; then
     fi
     select_notif "$notifs"
 elif [[ $print_fzf_static_reload_flag == "true" ]]; then
-    # when reloading fzf, the input shall not be truncated as this would break the layout
+    # this here is used as input for fzf when reloading,
+    # it should not be truncated as this would affect the functionality in fzf
     echo "$notifs"
 else
     # remove the first two eleemnts from the static display

--- a/gh-notify
+++ b/gh-notify
@@ -51,7 +51,7 @@ ${WHITE_BOLD}Key Bindings fzf${NC}
   ${GREEN}ctrl+p   ${NC}  view diff in patch format
   ${GREEN}ctrl+r   ${NC}  mark all displayed notifications as read and reload
   ${GREEN}ctrl+t   ${NC}  mark notification as read and reload
-  ${GREEN}ctrl+x   ${NC}  write a comment with the editor and quit
+  ${GREEN}ctrl+x   ${NC}  write a comment with the editor, mark the notification as read and quit
   ${GREEN}esc      ${NC}  quit
 
 ${WHITE_BOLD}Example${NC}
@@ -142,15 +142,17 @@ get_notifs() {
             iso8601: now | strftime("%Y-%m-%dT%H:%M:%SZ"),
             thread_id: .id,
             thread_state: (if .unread then "UNREAD" else "READ" end),
+            comment_url: .subject.latest_comment_url | tostring | split("/") | last,
             timefmt: colored(.updated_at | fromdateiso8601 | strftime("%d/%b %H:%M"); "gray"),
             owner: colored(.repository.owner.login; "cyan"),
             name: colored(.repository.name; "cyan_bold"),
             type: .subject.type,
-            url: (if .subject.url then .subject.url else "NONE" end),
+            url_COMMENT: "Some infos have to be pulled from this URL in later steps, so no string modifications.",
+            url: .subject.url | tostring,
             unread_symbol: colored((if .unread then "\u25cf" else "\u00a0" end);"magenta"),
             title: .subject.title
         } |
-        "\(.hidden_updated_at)\t\(.hidden_repository_full_name)\t\(.iso8601)\t\(.thread_id)\t\(.thread_state)\t\(.timefmt)\t\(.owner)\/\(.name)\t\(.type)\t\(.url)\t\(.unread_symbol)\t\(.title)"'
+        "\(.hidden_updated_at)\t\(.hidden_repository_full_name)\t\(.iso8601)\t\(.thread_id)\t\(.thread_state)\t\(.comment_url)\t\(.timefmt)\t\(.owner)\/\(.name)\t\(.type)\t\(.url)\t\(.unread_symbol)\t\(.title)"'
 }
 
 print_notifs() {
@@ -165,12 +167,12 @@ print_notifs() {
             page_num=$((page_num + 1))
         fi
         new_notifs=$(
-            echo "$page" | while IFS=$'\t' read -r hidden_updated_at hidden_repository_full_name iso8601 thread_id thread_state timefmt repo type url unread_symbol title number; do
+            echo "$page" | while IFS=$'\t' read -r hidden_updated_at hidden_repository_full_name iso8601 thread_id thread_state comment_url timefmt repo type url unread_symbol title number; do
                 if grep -q "Discussion" <<<"$type"; then
                     graphql_query_discussion=$'query ($filter: String!) { search(query: $filter, type: DISCUSSION, first: 1) { nodes { ... on Discussion { number }}}}'
                     # https://docs.github.com/en/search-github/searching-on-github/searching-discussions
                     number=$(gh api graphql --cache=100h --raw-field filter="$title in:title updated:>=$hidden_updated_at repo:$hidden_repository_full_name" --raw-field query="$graphql_query_discussion" --jq '.data.search.nodes | .[].number')
-                elif ! grep -q "^NONE" <<<"$url"; then
+                elif ! grep -q "^null" <<<"$url"; then
                     if grep -q "Commit" <<<"$type"; then
                         number=$(basename "$url" | head -c 7)
                     elif grep -q "Release" <<<"$type"; then
@@ -188,7 +190,7 @@ print_notifs() {
                     fi
                 fi
 
-                printf "\n%s\t%s\t%s\t%s\t%s\t%s ${GREEN}%s${NC} %s\t%s\n" "$iso8601" "$thread_id" "$thread_state" "$timefmt" "$repo" "$type" "$number" "$unread_symbol" "$title"
+                printf "\n%s\t%s\t%s\t%s\t%s\t%s\t%s ${GREEN}%s${NC} %s\t%s\n" "$iso8601" "$thread_id" "$thread_state" "$comment_url" "$timefmt" "$repo" "$type" "$number" "$unread_symbol" "$title"
             done
         )
         all_notifs="$all_notifs$new_notifs"
@@ -205,14 +207,21 @@ print_notifs() {
     echo "$all_notifs" | grep -v "$exclusion_string" | grep "$filter_string" | column -t -s $'\t'
 }
 
+mark_individual_read() {
+    if grep -q UNREAD <<<"${1:?"input thread_state missing"}"; then
+        gh api --silent --header $GH_REST_API_VERSION --method PATCH notifications/threads/"${2:?"input thread_id missing"}" ||
+            { echo "Failed to mark notification as read." >&2 && exit 1; }
+    fi
+}
+
 select_notif() {
     local notif_msg diff_pager open_notification_browser preview_notification selection key repo type num
     notif_msg="$1"
     # https://dandavison.github.io/delta
     diff_pager=$'if type -p delta >/dev/null; then delta --width ${FZF_PREVIEW_COLUMNS:-$COLUMNS}; else cat; fi'
-    open_notification_browser='if grep -q CheckSuite <<<{7}; then open https://github.com/{6}/actions ; elif grep -q Commit <<<{7}; then gh browse {8} -R {6} ; elif grep -q Discussion <<<{7}; then open https://github.com/{6}/discussions/{8} ; elif grep -qE "Issue|PullRequest" <<<{7}; then gh issue view {8} -wR {6}; elif grep -q "[Rr]elease" <<<{7}; then gh release view {8} -wR {6}; else gh repo view -w {6}; fi'
-    preview_notification='echo \[{4} {5} - {7}\] ;if grep -q Issue <<<{7}; then gh issue view {8} -R {6} --comments; elif grep -q PullRequest <<<\"{7}\"; then gh pr view {8} -R {6} --comments; elif grep -q "[Rr]elease" <<<{7}; then gh release view {8} -R {6}; else echo "Notification preview for {7} is not supported."; fi'
-    # If this were passed as a function to fzf, it would be called immediately when fzf is called, in spite of the fact that the assigned hotkey was not triggered.
+    open_notification_browser=$'unhashed_num=$(cut -d "#" -f2 <<<{9});if grep -q CheckSuite <<<{8}; then open https://github.com/{7}/actions ; elif grep -q Commit <<<{8}; then gh browse {9} -R {7} ; elif grep -q Discussion <<<{8}; then open https://github.com/{7}/discussions/{9} ; elif grep -qE "Issue|PullRequest" <<<{8}; then if grep -q null <<<{4} || test {4} = "$unhashed_num"; then gh issue view {9} -wR {7}; else open https://github.com/{7}/issues/${unhashed_num}#issuecomment-{4}; fi; elif grep -q "[Rr]elease" <<<{8}; then gh release view {9} -wR {7}; else gh repo view -w {7}; fi'
+    preview_notification='echo \[{5} {6} - {8}\] ;if grep -q Issue <<<{8}; then gh issue view {9} -R {7} --comments; elif grep -q PullRequest <<<\"{8}\"; then gh pr view {9} -R {7} --comments; elif grep -q "[Rr]elease" <<<{8}; then gh release view {9} -R {7}; else echo "Notification preview for {8} is not supported."; fi'
+    # If these were passed as a function to fzf, it would be called immediately when fzf is called, in spite of the fact that the assigned hotkey was not triggered.
     mark_all_read="gh api --silent --header $GH_REST_API_VERSION --method PUT notifications --raw-field last_read_at={1} --field read=true"
     mark_individual_read="if grep -q UNREAD <<<{3}; then gh api --silent --header $GH_REST_API_VERSION --method PATCH notifications/threads/{2}; fi"
 
@@ -221,7 +230,7 @@ select_notif() {
     # therefore the key to mark notifications as read shall not be ctrl-m.
     selection=$(
         SHELL="bash" fzf <<<"$notif_msg" \
-            --ansi --no-multi --with-nth 4.. \
+            --ansi --no-multi --with-nth 5.. \
             --delimiter '\s+' \
             --reverse --info=inline --pointer="▶" \
             --border horizontal --color "border:dim" \
@@ -230,8 +239,8 @@ select_notif() {
             --bind "change:first" \
             --bind "?:toggle-preview+change-preview:echo -e '$HELP_TEXT'" \
             --bind "ctrl-b:execute-silent:$open_notification_browser" \
-            --bind "ctrl-d:toggle-preview+change-preview:if grep -q PullRequest <<<{7}; then gh pr diff {8} -R {6} | $diff_pager; else $preview_notification; fi" \
-            --bind "ctrl-p:toggle-preview+change-preview:if grep -q PullRequest <<<{7}; then gh pr diff {8} --patch -R {6} | $diff_pager; else  $preview_notification; fi" \
+            --bind "ctrl-d:toggle-preview+change-preview:if grep -q PullRequest <<<{8}; then gh pr diff {9} -R {7} | $diff_pager; else $preview_notification; fi" \
+            --bind "ctrl-p:toggle-preview+change-preview:if grep -q PullRequest <<<{8}; then gh pr diff {9} --patch -R {7} | $diff_pager; else  $preview_notification; fi" \
             --bind "ctrl-r:execute-silent($mark_all_read)+reload:$reload_arguments" \
             --bind "ctrl-t:execute-silent($mark_individual_read)+reload:$reload_arguments" \
             --bind "tab:toggle-preview+change-preview:$preview_notification" \
@@ -242,7 +251,7 @@ select_notif() {
     )
 
     # actions that close fzf are defined below
-    read -r key _ thread_id thread_state _ _ repo type num _ <<<"$selection"
+    read -r key _ thread_id thread_state _ _ _ repo type num _ <<<"$selection"
     [[ -z "$type" ]] && exit 0
     case "$key" in
     enter)
@@ -255,11 +264,7 @@ select_notif() {
         else
             echo "Notification preview for $type is not supported."
         fi
-
-        if grep -q UNREAD <<<"$thread_state"; then
-            gh api --silent --header $GH_REST_API_VERSION --method PATCH notifications/threads/"$thread_id" ||
-                { echo "Failed to mark notification as read." >&2 && exit 1; }
-        fi
+        mark_individual_read "$thread_state" "$thread_id"
         ;;
     esc) exit 0 ;;
     ctrl-x)
@@ -268,6 +273,7 @@ select_notif() {
         else
             echo "Writing comments for $type is not supported."
         fi
+        mark_individual_read "$thread_state" "$thread_id"
         ;;
     esac
 }
@@ -284,9 +290,9 @@ fi
 notifs="$(print_notifs)"
 if [[ -z "$notifs" ]]; then
     # TODO: exit fzf when the list is empty.
-    # 3x NO-BREAK SPACE when fzf is reloaded and the list is empty,
+    # 4x NO-BREAK SPACE when fzf is reloaded and the list is empty,
     # this message is displayed and the first three elements are hidden.
-    echo "      All caught up!"
+    echo "        All caught up!"
     exit 0
 elif [[ $print_static_flag == "false" ]]; then
     if ! type -p fzf >/dev/null; then
@@ -302,11 +308,11 @@ elif [[ $print_static_flag == "false" ]]; then
     fi
     select_notif "$notifs"
 elif [[ $print_fzf_static_reload_flag == "true" ]]; then
-    # this here is used as input for fzf when reloading,
-    # it should not be truncated as this would affect the functionality in fzf
+    # this is used as input for fzf when reloading,
+    # it should not be truncated, as this would affect the functionality of fzf
     echo "$notifs"
 else
-    # remove the first two eleemnts from the static display
+    # remove unimportant elements from the static display
     # '[[:blank:]]' matches horizontal whitespace characters (spaces/ tabs)
-    echo "$notifs" | sed -E 's/^([^[:blank:]]+[[:blank:]]+){3}//'
+    echo "$notifs" | sed -E 's/^([^[:blank:]]+[[:blank:]]+){4}//'
 fi

--- a/gh-notify
+++ b/gh-notify
@@ -128,16 +128,14 @@ get_notifs() {
             "cyan": "\u001b[36m",
             "cyan_bold": "\u001b[1;36m",
             "gray": "\u001b[90m",
-            "green": "\u001b[32m",
             "magenta": "\u001b[35m",
             "reset": "\u001b[0m"
         };
         def colored(text; color):
             colors[color] + text + colors.reset;
         .[] | {
-            hidden_COMMENT: "Hidden data points without color codes used in GraphQL query",
-            hidden_updated_at: .updated_at | fromdateiso8601 | strftime("%Y-%m"),
-            hidden_repository_full_name: .repository.full_name,
+            updated_short: .updated_at | fromdateiso8601 | strftime("%Y-%m"),
+            full_name: .repository.full_name,
             iso8601: now | strftime("%Y-%m-%dT%H:%M:%SZ"),
             thread_id: .id,
             thread_state: (if .unread then "UNREAD" else "READ" end),
@@ -150,13 +148,14 @@ get_notifs() {
             url: .subject.url | tostring,
             unread_symbol: colored((if .unread then "\u25cf" else "\u00a0" end);"magenta"),
             title: .subject.title
-        } | [.hidden_updated_at, .hidden_repository_full_name, .iso8601, .thread_id, .thread_state, .comment_url, .timefmt, "\(.owner)/\(.name)", .type, .url, .unread_symbol, .title ] | @tsv'
+        } | ["updated:>=\(.updated_short) repo:\(.full_name)", .iso8601, .thread_id, .thread_state, .comment_url, .timefmt, "\(.owner)/\(.name)", .type, .url, .unread_symbol, .title ] | @tsv'
 }
 
 print_notifs() {
-    local graphql_query_discussion
+    local all_notifs page_num page new_notifs graphql_query_discussion
     all_notifs=""
     page_num=1
+    graphql_query_discussion=$'query ($filter: String!) { search(query: $filter, type: DISCUSSION, first: 1) { nodes { ... on Discussion { number }}}}'
     while true; do
         page=$(get_notifs $page_num) || { echo "Failed to get notifications." >&2 && exit 1; }
         if [ "$page" == "" ]; then
@@ -165,11 +164,10 @@ print_notifs() {
             page_num=$((page_num + 1))
         fi
         new_notifs=$(
-            echo "$page" | while IFS=$'\t' read -r hidden_updated_at hidden_repository_full_name iso8601 thread_id thread_state comment_url timefmt repo type url unread_symbol title number; do
+            echo "$page" | while IFS=$'\t' read -r qualifier iso8601 thread_id thread_state comment_url timefmt repo type url unread_symbol title number; do
                 if grep -q "Discussion" <<<"$type"; then
-                    graphql_query_discussion=$'query ($filter: String!) { search(query: $filter, type: DISCUSSION, first: 1) { nodes { ... on Discussion { number }}}}'
                     # https://docs.github.com/en/search-github/searching-on-github/searching-discussions
-                    number=$(gh api graphql --cache=100h --raw-field filter="$title in:title updated:>=$hidden_updated_at repo:$hidden_repository_full_name" --raw-field query="$graphql_query_discussion" --jq '.data.search.nodes | .[].number') || { echo "Failed GraphQL discussion query." >&2 && exit 1; }
+                    number=$(gh api graphql --cache=100h --raw-field filter="$title in:title $qualifier" --raw-field query="$graphql_query_discussion" --jq '.data.search.nodes | .[].number') || { echo "Failed GraphQL discussion query." >&2 && exit 1; }
                 elif ! grep -q "^null" <<<"$url"; then
                     if grep -q "Commit" <<<"$type"; then
                         number=$(basename "$url" | head -c 7)

--- a/gh-notify
+++ b/gh-notify
@@ -42,7 +42,7 @@ ${WHITE_BOLD}Flags${NC}
 
 ${WHITE_BOLD}Key Bindings fzf${NC}
   ${GREEN}?        ${NC}  toggle help
-  ${GREEN}enter    ${NC}  print notification and exit
+  ${GREEN}enter    ${NC}  print notification, marked as read and exit
   ${GREEN}tab      ${NC}  toggle preview notification
   ${GREEN}shift+tab${NC}  change preview window size
   ${GREEN}shift+↑↓ ${NC}  scroll the preview up/ down
@@ -50,6 +50,7 @@ ${WHITE_BOLD}Key Bindings fzf${NC}
   ${GREEN}ctrl+d   ${NC}  view diff
   ${GREEN}ctrl+p   ${NC}  view diff in patch format
   ${GREEN}ctrl+r   ${NC}  mark all displayed notifications as read and reload
+  ${GREEN}ctrl+t   ${NC}  mark notification as read and reload
   ${GREEN}ctrl+x   ${NC}  write a comment with the editor and exit
   ${GREEN}esc      ${NC}  exit
 EOF
@@ -63,14 +64,18 @@ mark_read_flag='false'
 num_notifications='0'
 exclusion_string='XXX_BOGUS_STRING_THAT_SHOULD_NOT_EXIST_XXX'
 filter_string=''
+# this flag outputs all items in the list that fzf receives as an input
+# it is not listed as an official flag in the docs, as it is used for reloading fzf only
+print_fzf_static_reload_flag='false'
+
 # UTC time ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
 # https://docs.github.com/en/rest/overview/resources-in-the-rest-api#timezones
 timestamp=$(date +"%Y-%m-%dT%H:%M:%S%z")
 # https://github.com/mislav/gh-branch/blob/main/gh-branch#L105
-# this trick only works with the -s flag
-reload_arguments="$0 $* -s"
+# this trick only works with the '-s' and '-z' flag
+reload_arguments="$0 $* -sz"
 
-while getopts 'e:f:n:pawhsr' flag; do
+while getopts 'e:f:n:pawhsrz' flag; do
     case "${flag}" in
     n) num_notifications="${OPTARG}" ;;
     e) exclusion_string="${OPTARG}" ;;
@@ -80,6 +85,7 @@ while getopts 'e:f:n:pawhsr' flag; do
     p) only_participating_flag='true' ;;
     s) print_static_flag='true' ;;
     r) mark_read_flag='true' ;;
+    z) print_fzf_static_reload_flag='true' ;;
     h)
         # the -e option to enable the interpretation of backslash escapes,
         # so that the ANSI escape sequences are correctly interpreted as color codes
@@ -108,27 +114,30 @@ get_notifs() {
         local_page_size=$num_notifications
     fi
     printf >&2 "." # "marching ants" because sometimes this takes a bit.
+    # Use '-F/--field' to pass a variable that is a number, Boolean, or null. Use '-f/--raw-field' for other variables.
     gh api --header "X-GitHub-Api-Version:$GH_REST_API_VERSION" --method GET notifications --cache=0s \
-        -f per_page="$local_page_size" -f all="$include_all_flag" -f participating="$only_participating_flag" -f page="$page_num" \
+        --field per_page="$local_page_size" --field page="$page_num" \
+        --field participating="$only_participating_flag" --field all="$include_all_flag" \
         --template '
     {{- range . -}}
         {{- /* Comment: Hidden data points without color codes used in GraphQL query */ -}}
         {{- printf "%s\t%s\t" (timefmt "2006-01" .updated_at) .repository.full_name -}}
         {{- /* COMMENT: timefmt must use the reference time Mon Jan 2 15:04:05 MST 2006 to format a given time */ -}}
-        {{- printf "%s\t%s\t%s\t" (timefmt "02/Jan 15:04" .updated_at | color "gray+h") .subject.type .subject.title -}}
+        {{- printf "%s\t%s\t%s\t%s\t" .id (timefmt "02/Jan 15:04" .updated_at | color "gray+h") .subject.type .subject.title -}}
         {{- printf "%s%s%s\t" (.repository.owner.login | color "cyan+h") ("/" | color "gray+h") (.repository.name | color "cyan+hb") -}}
         {{- if .subject.url -}}{{- printf "%s\t" .subject.url -}}
             {{- else -}}{{- printf " \t" -}}
         {{- end -}}
-        {{- if .unread -}}{{- printf "%s\n" ("●" | color "magenta") -}}
+        {{- /* COMMENT: Unicode for ● (Black Circle) */ -}}
+        {{- if .unread -}}{{- printf "%s\n" ("\u25cf" | color "magenta") -}}
             {{- /* COMMENT: Empty strings are colorized to keep the columns in line. */ -}}
-            {{- else -}}{{- printf "%s\n" (" " | color "magenta") -}}
+            {{- else -}}{{- printf "%s\n" ("" | color "magenta") -}}
         {{- end -}}
     {{- end -}}'
 }
 
 print_notifs() {
-    local hidden_updated_at hidden_repository_full_name timefmt type title repo url unread number graphql_query_discussion
+    local hidden_updated_at hidden_repository_full_name thread_id thread_id_state timefmt type title repo url unread_symbol number graphql_query_discussion
     all_notifs=""
     page_num=1
     while true; do
@@ -139,7 +148,7 @@ print_notifs() {
             page_num=$((page_num + 1))
         fi
         new_notifs=$(
-            echo "$page" | while IFS=$'\t' read -r hidden_updated_at hidden_repository_full_name timefmt type title repo url unread; do
+            echo "$page" | while IFS=$'\t' read -r hidden_updated_at hidden_repository_full_name thread_id timefmt type title repo url unread_symbol; do
                 if grep -q "Discussion" <<<"$type"; then
                     graphql_query_discussion=$'query ($filter: String!) { search(query: $filter, type: DISCUSSION, first: 1) { nodes { ... on Discussion { number }}}}'
                     # https://docs.github.com/en/search-github/searching-on-github/searching-discussions
@@ -147,10 +156,10 @@ print_notifs() {
                 elif grep -q "Commit" <<<"$type"; then
                     number=$(basename "$url" | head -c 7)
                 elif grep -q "Release" <<<"$type"; then
-                    if grep -q "^http" <<<"$url" && gh api --cache 20s --header "X-GitHub-Api-Version:$GH_REST_API_VERSION" --method GET "$url" --silent 2>/dev/null; then
+                    if grep -q "^http" <<<"$url" && gh api --cache=20s --header "X-GitHub-Api-Version:$GH_REST_API_VERSION" --method GET "$url" --silent 2>/dev/null; then
                         #  URL works
                         release_info=()
-                        while IFS='' read -r line; do release_info+=("$line"); done < <(gh api --cache 20s --header "X-GitHub-Api-Version:$GH_REST_API_VERSION" --method GET "$url" --jq '.tag_name, .prerelease')
+                        while IFS='' read -r line; do release_info+=("$line"); done < <(gh api --cache=20s --header "X-GitHub-Api-Version:$GH_REST_API_VERSION" --method GET "$url" --jq '.tag_name, .prerelease')
                         number="${release_info[0]}"
                         "${release_info[1]}" && type="Pre-release"
                     else
@@ -162,7 +171,13 @@ print_notifs() {
                     # ${variable//search/replace} - https://wiki.bash-hackers.org/syntax/pe
                     number=${url/*\//#}
                 fi
-                printf "\n%s\t%s\t%s ${GREEN}%s${NC} %s\t%s\n" "$timefmt" "$repo" "$type" "$number" "$unread" "$title"
+
+                if [[ "$unread_symbol" =~ $'\u25cf' ]]; then
+                    thread_id_state="UNREAD"
+                else
+                    thread_id_state="READ"
+                fi
+                printf "\n%s\t%s\t%s\t%s\t%s ${GREEN}%s${NC} %s\t%s\n" "$thread_id" "$thread_id_state" "$timefmt" "$repo" "$type" "$number" "$unread_symbol" "$title"
             done
         )
         all_notifs="$all_notifs$new_notifs"
@@ -184,10 +199,11 @@ select_notif() {
     notif_msg="$1"
     # https://dandavison.github.io/delta
     diff_pager=$'if type -p delta >/dev/null; then delta --width ${FZF_PREVIEW_COLUMNS:-$COLUMNS}; else cat; fi'
-    open_notification_browser='if grep -q CheckSuite <<<{4}; then open https://github.com/{3}/actions ; elif grep -q Commit <<<{4}; then gh browse {5} -R {3} ; elif grep -q Discussion <<<{4}; then open https://github.com/{3}/discussions/{5} ; elif grep -qE "Issue|PullRequest" <<<{4}; then gh issue view {5} -wR {3}; elif grep -q "[Rr]elease" <<<{4}; then gh release view {5} -wR {3}; else gh repo view -w {3}; fi'
-    preview_notification='echo \[{1} {2} - {4}\] ;if grep -q Issue <<<{4}; then gh issue view {5} -R {3} --comments; elif grep -q PullRequest <<<\"{4}\"; then gh pr view {5} -R {3} --comments; elif grep -q "[Rr]elease" <<<{4}; then gh release view {5} -R {3}; else echo "Notification preview for {4} is not supported."; fi'
+    open_notification_browser='if grep -q CheckSuite <<<{6}; then open https://github.com/{5}/actions ; elif grep -q Commit <<<{6}; then gh browse {7} -R {5} ; elif grep -q Discussion <<<{6}; then open https://github.com/{5}/discussions/{7} ; elif grep -qE "Issue|PullRequest" <<<{6}; then gh issue view {7} -wR {5}; elif grep -q "[Rr]elease" <<<{6}; then gh release view {7} -wR {5}; else gh repo view -w {5}; fi'
+    preview_notification='echo \[{3} {4} - {6}\] ;if grep -q Issue <<<{6}; then gh issue view {7} -R {5} --comments; elif grep -q PullRequest <<<\"{6}\"; then gh pr view {7} -R {5} --comments; elif grep -q "[Rr]elease" <<<{6}; then gh release view {7} -R {5}; else echo "Notification preview for {6} is not supported."; fi'
     # If this were passed as a function to fzf, it would be called immediately when fzf is called, in spite of the fact that the assigned hotkey was not triggered.
-    fzf_mark_read="gh api --header X-GitHub-Api-Version:$GH_REST_API_VERSION --method PUT notifications -f last_read_at=$timestamp -F read=true --silent"
+    mark_all_read="gh api --silent --header X-GitHub-Api-Version:$GH_REST_API_VERSION --method PUT notifications --raw-field last_read_at=$timestamp --field read=true"
+    mark_individual_read="if grep -q UNREAD <<<{2}; then gh api --silent --header X-GitHub-Api-Version:$GH_REST_API_VERSION --method PATCH notifications/threads/{1}; fi"
 
     # See the man page (man fzf) for an explanation of the arguments.
     # The key combination ctrl-m is a synonym for enter,
@@ -195,16 +211,18 @@ select_notif() {
     selection=$(
         SHELL="bash" fzf <<<"$notif_msg" \
             --ansi --no-multi \
+            --with-nth 3.. \
             --reverse --info=inline --pointer="▶" \
             --border horizontal --color "border:dim" \
             --header "? Help · esc Quit" --color "header:green:italic:dim" \
-            --prompt "GitHub Notifications > " --color "prompt:80,info:40"\
+            --prompt "GitHub Notifications > " --color "prompt:80,info:40" \
             --bind "change:first" \
             --bind "?:toggle-preview+change-preview:echo -e '$HELP_TEXT'" \
             --bind "ctrl-b:execute-silent:$open_notification_browser" \
-            --bind "ctrl-d:toggle-preview+change-preview:if grep -q PullRequest <<<{4}; then gh pr diff {5} -R {3} | $diff_pager; else $preview_notification; fi" \
-            --bind "ctrl-p:toggle-preview+change-preview:if grep -q PullRequest <<<{4}; then gh pr diff {5} --patch -R {3} | $diff_pager; else  $preview_notification; fi" \
-            --bind "ctrl-r:+execute-silent($fzf_mark_read)+reload:$reload_arguments" \
+            --bind "ctrl-d:toggle-preview+change-preview:if grep -q PullRequest <<<{6}; then gh pr diff {7} -R {5} | $diff_pager; else $preview_notification; fi" \
+            --bind "ctrl-p:toggle-preview+change-preview:if grep -q PullRequest <<<{6}; then gh pr diff {7} --patch -R {5} | $diff_pager; else  $preview_notification; fi" \
+            --bind "ctrl-r:execute-silent($mark_all_read)+reload:$reload_arguments" \
+            --bind "ctrl-t:execute-silent($mark_individual_read)+reload:$reload_arguments" \
             --bind "tab:toggle-preview+change-preview:$preview_notification" \
             --bind "btab:change-preview-window(75%:nohidden|75%:down:nohidden:border-top|nohidden)" \
             --preview-window wrap:"$preview_window_visibility":50%:right:border-left \
@@ -213,7 +231,7 @@ select_notif() {
     )
 
     # actions that close fzf are defined below
-    read -r key _ _ repo type num _ <<<"$selection"
+    read -r key thread_id thread_id_state _ _ repo type num _ <<<"$selection"
     [[ -z "$type" ]] && exit 0
     case "$key" in
     enter)
@@ -225,6 +243,11 @@ select_notif() {
             gh release view "$num" -R "$repo"
         else
             echo "Notification preview for $type is not supported."
+        fi
+
+        if grep -q UNREAD <<<"$thread_id_state"; then
+            gh api --silent --header X-GitHub-Api-Version:$GH_REST_API_VERSION --method PATCH notifications/threads/"$thread_id" ||
+                { echo "Failed to mark notification as read." >&2 && exit 1; }
         fi
         ;;
     esc) exit 0 ;;
@@ -239,7 +262,7 @@ select_notif() {
 }
 
 if [[ $mark_read_flag == "true" ]]; then
-    gh api --header "X-GitHub-Api-Version:$GH_REST_API_VERSION" --method PUT notifications -f last_read_at="$timestamp" -F read=true --silent
+    gh api --header "X-GitHub-Api-Version:$GH_REST_API_VERSION" --method PUT notifications --raw-field last_read_at="$timestamp" --field read=true --silent
     exit 0
 fi
 
@@ -259,8 +282,12 @@ elif [[ $print_static_flag == "false" ]]; then
         echo "Minimum required \`fzf\` version is: $MIN_FZF_VERSION"
         exit 1
     fi
-
     select_notif "$notifs"
-else
+elif [[ $print_fzf_static_reload_flag == "true" ]]; then
+    # when reloading fzf, the input shall not be truncated as this would break the layout
     echo "$notifs"
+else
+    # remove the first two eleemnts from the static display
+    # '[[:blank:]]' matches horizontal whitespace characters (spaces/ tabs)
+    echo "$notifs" | sed -E 's/^([^[:blank:]]+[[:blank:]]+){2}//'
 fi

--- a/gh-notify
+++ b/gh-notify
@@ -284,10 +284,10 @@ fi
 
 notifs="$(print_notifs)"
 if [[ -z "$notifs" ]]; then
-    # TODO: exit fzf when the list is empty and remove no-break spaces.
-    # 4x NO-BREAK SPACE when fzf is reloaded and the list is empty,
-    # this message is displayed and the first elements are hidden.
-    echo "        All caught up!"
+    # TODO: exit fzf automatically if the list is empty after a reload
+    # workaround, since fzf hides the first elements with '-with-nth'
+    # if the list is empty on a reload, the message would be hidden, so `\b '(backspace) is added
+    echo -e '\b \b \b \b \bAll caught up!'
     exit 0
 elif [[ $print_static_flag == "false" ]]; then
     if ! type -p fzf >/dev/null; then

--- a/gh-notify
+++ b/gh-notify
@@ -17,7 +17,6 @@ export GH_PAGER="cat"
 # CheckSuite, Commit, Discussion, Issue, PullRequest, Release, RepositoryVulnerabilityAlert, ...
 
 GREEN='\033[0;32m'
-MAGENTA='\033[0;35m'
 NC='\033[0m'
 WHITE_BOLD='\033[1m'
 
@@ -75,7 +74,7 @@ print_fzf_static_reload_flag='false'
 
 # UTC time ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
 # https://docs.github.com/en/rest/overview/resources-in-the-rest-api#timezones
-timestamp=$(date +"%Y-%m-%dT%H:%M:%S%z")
+timestamp=$(date +"%Y-%m-%dT%H:%M:%SZ")
 # https://github.com/mislav/gh-branch/blob/main/gh-branch#L105
 # this trick only works with the '-s' and '-z' flag
 reload_arguments="$0 $* -sz"
@@ -124,23 +123,38 @@ get_notifs() {
     gh api --header "$GH_REST_API_VERSION" --method GET notifications --cache=0s \
         --field per_page="$local_page_size" --field page="$page_num" \
         --field participating="$only_participating_flag" --field all="$include_all_flag" \
-        --template '
-    {{- range . -}}
-        {{- /* COMMENT: Hidden data points without color codes used in GraphQL query */ -}}
-        {{- printf "%s\t%s\t" (timefmt "2006-01" .updated_at) .repository.full_name -}}
-        {{- /* COMMENT: timefmt must use the reference time Mon Jan 2 15:04:05 MST 2006 to format a given time */ -}}
-        {{- $thread_state := "READ" -}}
-        {{- if .unread -}}{{- $thread_state = "UNREAD" -}}{{- end -}}
-        {{- printf "%s\t%s\t%s\t" .id $thread_state (timefmt "02/Jan 15:04" .updated_at | color "gray+h") -}}
-        {{- printf "%s%s%s\t" (.repository.owner.login | color "cyan+h") ("/" | color "gray+h") (.repository.name | color "cyan+hb") -}}
-        {{- $url := "NONE" -}}
-        {{- if .subject.url -}}{{- $url = .subject.url -}}{{- end -}}
-        {{- printf "%s\t%s\t%s\n" .subject.type $url .subject.title -}}
-    {{- end -}}'
+        --jq \
+        'def colors:
+        {
+            "cyan": "\u001b[36m",
+            "cyan_bold": "\u001b[1;36m",
+            "gray": "\u001b[90m",
+            "green": "\u001b[32m",
+            "magenta": "\u001b[35m",
+            "reset": "\u001b[0m"
+        };
+        def colored(text; color):
+            colors[color] + text + colors.reset;
+        .[] | {
+            hidden_COMMENT: "Hidden data points without color codes used in GraphQL query",
+            hidden_updated_at: .updated_at | fromdateiso8601 | strftime("%Y-%m"),
+            hidden_repository_full_name: .repository.full_name,
+            iso8601: now | strftime("%Y-%m-%dT%H:%M:%SZ"),
+            thread_id: .id,
+            thread_state: (if .unread then "UNREAD" else "READ" end),
+            timefmt: colored(.updated_at | fromdateiso8601 | strftime("%d/%b %H:%M"); "gray"),
+            owner: colored(.repository.owner.login; "cyan"),
+            name: colored(.repository.name; "cyan_bold"),
+            type: .subject.type,
+            url: (if .subject.url then .subject.url else "NONE" end),
+            unread_symbol: colored((if .unread then "\u25cf" else "\u00a0" end);"magenta"),
+            title: .subject.title
+        } |
+        "\(.hidden_updated_at)\t\(.hidden_repository_full_name)\t\(.iso8601)\t\(.thread_id)\t\(.thread_state)\t\(.timefmt)\t\(.owner)\/\(.name)\t\(.type)\t\(.url)\t\(.unread_symbol)\t\(.title)"'
 }
 
 print_notifs() {
-    local hidden_updated_at hidden_repository_full_name thread_id thread_state timefmt repo type url unread_symbol title number graphql_query_discussion
+    local graphql_query_discussion
     all_notifs=""
     page_num=1
     while true; do
@@ -151,7 +165,7 @@ print_notifs() {
             page_num=$((page_num + 1))
         fi
         new_notifs=$(
-            echo "$page" | while IFS=$'\t' read -r hidden_updated_at hidden_repository_full_name thread_id thread_state timefmt repo type url title number; do
+            echo "$page" | while IFS=$'\t' read -r hidden_updated_at hidden_repository_full_name iso8601 thread_id thread_state timefmt repo type url unread_symbol title number; do
                 if grep -q "Discussion" <<<"$type"; then
                     graphql_query_discussion=$'query ($filter: String!) { search(query: $filter, type: DISCUSSION, first: 1) { nodes { ... on Discussion { number }}}}'
                     # https://docs.github.com/en/search-github/searching-on-github/searching-discussions
@@ -174,11 +188,7 @@ print_notifs() {
                     fi
                 fi
 
-                unread_symbol=""
-                # Unicode for ● (Black Circle)
-                [[ "$thread_state" = "UNREAD" ]] && unread_symbol=$'\u25cf'
-
-                printf "\n%s\t%s\t%s\t%s\t%s ${GREEN}%s${NC} ${MAGENTA}%s${NC}\t%s\n" "$thread_id" "$thread_state" "$timefmt" "$repo" "$type" "$number" "$unread_symbol" "$title"
+                printf "\n%s\t%s\t%s\t%s\t%s\t%s ${GREEN}%s${NC} %s\t%s\n" "$iso8601" "$thread_id" "$thread_state" "$timefmt" "$repo" "$type" "$number" "$unread_symbol" "$title"
             done
         )
         all_notifs="$all_notifs$new_notifs"
@@ -200,19 +210,19 @@ select_notif() {
     notif_msg="$1"
     # https://dandavison.github.io/delta
     diff_pager=$'if type -p delta >/dev/null; then delta --width ${FZF_PREVIEW_COLUMNS:-$COLUMNS}; else cat; fi'
-    open_notification_browser='if grep -q CheckSuite <<<{6}; then open https://github.com/{5}/actions ; elif grep -q Commit <<<{6}; then gh browse {7} -R {5} ; elif grep -q Discussion <<<{6}; then open https://github.com/{5}/discussions/{7} ; elif grep -qE "Issue|PullRequest" <<<{6}; then gh issue view {7} -wR {5}; elif grep -q "[Rr]elease" <<<{6}; then gh release view {7} -wR {5}; else gh repo view -w {5}; fi'
-    preview_notification='echo \[{3} {4} - {6}\] ;if grep -q Issue <<<{6}; then gh issue view {7} -R {5} --comments; elif grep -q PullRequest <<<\"{6}\"; then gh pr view {7} -R {5} --comments; elif grep -q "[Rr]elease" <<<{6}; then gh release view {7} -R {5}; else echo "Notification preview for {6} is not supported."; fi'
+    open_notification_browser='if grep -q CheckSuite <<<{7}; then open https://github.com/{6}/actions ; elif grep -q Commit <<<{7}; then gh browse {8} -R {6} ; elif grep -q Discussion <<<{7}; then open https://github.com/{6}/discussions/{8} ; elif grep -qE "Issue|PullRequest" <<<{7}; then gh issue view {8} -wR {6}; elif grep -q "[Rr]elease" <<<{7}; then gh release view {8} -wR {6}; else gh repo view -w {6}; fi'
+    preview_notification='echo \[{4} {5} - {7}\] ;if grep -q Issue <<<{7}; then gh issue view {8} -R {6} --comments; elif grep -q PullRequest <<<\"{7}\"; then gh pr view {8} -R {6} --comments; elif grep -q "[Rr]elease" <<<{7}; then gh release view {8} -R {6}; else echo "Notification preview for {7} is not supported."; fi'
     # If this were passed as a function to fzf, it would be called immediately when fzf is called, in spite of the fact that the assigned hotkey was not triggered.
-    mark_all_read="gh api --silent --header $GH_REST_API_VERSION --method PUT notifications --raw-field last_read_at=$timestamp --field read=true"
-    mark_individual_read="if grep -q UNREAD <<<{2}; then gh api --silent --header $GH_REST_API_VERSION --method PATCH notifications/threads/{1}; fi"
+    mark_all_read="gh api --silent --header $GH_REST_API_VERSION --method PUT notifications --raw-field last_read_at={1} --field read=true"
+    mark_individual_read="if grep -q UNREAD <<<{3}; then gh api --silent --header $GH_REST_API_VERSION --method PATCH notifications/threads/{2}; fi"
 
     # See the man page (man fzf) for an explanation of the arguments.
     # The key combination ctrl-m is a synonym for enter,
     # therefore the key to mark notifications as read shall not be ctrl-m.
     selection=$(
         SHELL="bash" fzf <<<"$notif_msg" \
-            --ansi --no-multi \
-            --delimiter '\s+' --with-nth 3.. \
+            --ansi --no-multi --with-nth 4.. \
+            --delimiter '\s+' \
             --reverse --info=inline --pointer="▶" \
             --border horizontal --color "border:dim" \
             --header "? help · esc quit" --color "header:green:italic:dim" \
@@ -220,8 +230,8 @@ select_notif() {
             --bind "change:first" \
             --bind "?:toggle-preview+change-preview:echo -e '$HELP_TEXT'" \
             --bind "ctrl-b:execute-silent:$open_notification_browser" \
-            --bind "ctrl-d:toggle-preview+change-preview:if grep -q PullRequest <<<{6}; then gh pr diff {7} -R {5} | $diff_pager; else $preview_notification; fi" \
-            --bind "ctrl-p:toggle-preview+change-preview:if grep -q PullRequest <<<{6}; then gh pr diff {7} --patch -R {5} | $diff_pager; else  $preview_notification; fi" \
+            --bind "ctrl-d:toggle-preview+change-preview:if grep -q PullRequest <<<{7}; then gh pr diff {8} -R {6} | $diff_pager; else $preview_notification; fi" \
+            --bind "ctrl-p:toggle-preview+change-preview:if grep -q PullRequest <<<{7}; then gh pr diff {8} --patch -R {6} | $diff_pager; else  $preview_notification; fi" \
             --bind "ctrl-r:execute-silent($mark_all_read)+reload:$reload_arguments" \
             --bind "ctrl-t:execute-silent($mark_individual_read)+reload:$reload_arguments" \
             --bind "tab:toggle-preview+change-preview:$preview_notification" \
@@ -232,7 +242,7 @@ select_notif() {
     )
 
     # actions that close fzf are defined below
-    read -r key thread_id thread_state _ _ repo type num _ <<<"$selection"
+    read -r key _ thread_id thread_state _ _ repo type num _ <<<"$selection"
     [[ -z "$type" ]] && exit 0
     case "$key" in
     enter)
@@ -273,10 +283,10 @@ fi
 
 notifs="$(print_notifs)"
 if [[ -z "$notifs" ]]; then
-    # TODO: quit fzf if list is empty
-    # 2x NO-BREAK SPACE when fzf is reloaded and the list is empty,
-    # this message is displayed and the first two elements are hidden.
-    echo "    All caught up!"
+    # TODO: exit fzf when the list is empty.
+    # 3x NO-BREAK SPACE when fzf is reloaded and the list is empty,
+    # this message is displayed and the first three elements are hidden.
+    echo "      All caught up!"
     exit 0
 elif [[ $print_static_flag == "false" ]]; then
     if ! type -p fzf >/dev/null; then
@@ -298,5 +308,5 @@ elif [[ $print_fzf_static_reload_flag == "true" ]]; then
 else
     # remove the first two eleemnts from the static display
     # '[[:blank:]]' matches horizontal whitespace characters (spaces/ tabs)
-    echo "$notifs" | sed -E 's/^([^[:blank:]]+[[:blank:]]+){2}//'
+    echo "$notifs" | sed -E 's/^([^[:blank:]]+[[:blank:]]+){3}//'
 fi

--- a/gh-notify
+++ b/gh-notify
@@ -54,6 +54,10 @@ ${WHITE_BOLD}Key Bindings fzf${NC}
   ${GREEN}ctrl+t   ${NC}  mark notification as read and reload
   ${GREEN}ctrl+x   ${NC}  write a comment with the editor and quit
   ${GREEN}esc      ${NC}  quit
+
+${WHITE_BOLD}Example${NC}
+    # View the last 20 notifications
+    gh notify -an 20
 EOF
 )
 

--- a/gh-notify
+++ b/gh-notify
@@ -273,7 +273,10 @@ fi
 
 notifs="$(print_notifs)"
 if [[ -z "$notifs" ]]; then
-    echo "All caught up!"
+    # TODO: quit fzf if list is empty
+    # 2x NO-BREAK SPACE when fzf is reloaded and the list is empty,
+    # this message is displayed and the first two elements are hidden.
+    echo "    All caught up!"
     exit 0
 elif [[ $print_static_flag == "false" ]]; then
     if ! type -p fzf >/dev/null; then

--- a/gh-notify
+++ b/gh-notify
@@ -150,8 +150,7 @@ get_notifs() {
             url: .subject.url | tostring,
             unread_symbol: colored((if .unread then "\u25cf" else "\u00a0" end);"magenta"),
             title: .subject.title
-        } |
-        "\(.hidden_updated_at)\t\(.hidden_repository_full_name)\t\(.iso8601)\t\(.thread_id)\t\(.thread_state)\t\(.comment_url)\t\(.timefmt)\t\(.owner)\/\(.name)\t\(.type)\t\(.url)\t\(.unread_symbol)\t\(.title)"'
+        } | [.hidden_updated_at, .hidden_repository_full_name, .iso8601, .thread_id, .thread_state, .comment_url, .timefmt, "\(.owner)/\(.name)", .type, .url, .unread_symbol, .title ] | @tsv'
 }
 
 print_notifs() {

--- a/gh-notify
+++ b/gh-notify
@@ -42,7 +42,7 @@ ${WHITE_BOLD}Flags${NC}
 
 ${WHITE_BOLD}Key Bindings fzf${NC}
   ${GREEN}?        ${NC}  toggle help
-  ${GREEN}enter    ${NC}  print notification, marked as read and exit
+  ${GREEN}enter    ${NC}  print and mark the notification as read and quit
   ${GREEN}tab      ${NC}  toggle preview notification
   ${GREEN}shift+tab${NC}  change preview window size
   ${GREEN}shift+↑↓ ${NC}  scroll the preview up/ down
@@ -51,8 +51,8 @@ ${WHITE_BOLD}Key Bindings fzf${NC}
   ${GREEN}ctrl+p   ${NC}  view diff in patch format
   ${GREEN}ctrl+r   ${NC}  mark all displayed notifications as read and reload
   ${GREEN}ctrl+t   ${NC}  mark notification as read and reload
-  ${GREEN}ctrl+x   ${NC}  write a comment with the editor and exit
-  ${GREEN}esc      ${NC}  exit
+  ${GREEN}ctrl+x   ${NC}  write a comment with the editor and quit
+  ${GREEN}esc      ${NC}  quit
 EOF
 )
 
@@ -211,10 +211,10 @@ select_notif() {
     selection=$(
         SHELL="bash" fzf <<<"$notif_msg" \
             --ansi --no-multi \
-            --with-nth 3.. \
+            --delimiter '  ' --with-nth 3.. \
             --reverse --info=inline --pointer="▶" \
             --border horizontal --color "border:dim" \
-            --header "? Help · esc Quit" --color "header:green:italic:dim" \
+            --header "? help · esc quit" --color "header:green:italic:dim" \
             --prompt "GitHub Notifications > " --color "prompt:80,info:40" \
             --bind "change:first" \
             --bind "?:toggle-preview+change-preview:echo -e '$HELP_TEXT'" \

--- a/gh-notify
+++ b/gh-notify
@@ -262,6 +262,10 @@ select_notif() {
     esac
 }
 
+# quick check if you can connect to the GitHub API
+if ! gh api --silent --header "$GH_REST_API_VERSION" zen; then
+    exit 1
+fi
 if [[ $mark_read_flag == "true" ]]; then
     gh api --header "$GH_REST_API_VERSION" --method PUT notifications --raw-field last_read_at="$timestamp" --field read=true --silent
     exit 0

--- a/gh-notify
+++ b/gh-notify
@@ -211,7 +211,7 @@ select_notif() {
     selection=$(
         SHELL="bash" fzf <<<"$notif_msg" \
             --ansi --no-multi \
-            --delimiter '  ' --with-nth 3.. \
+            --delimiter '\s+' --with-nth 3.. \
             --reverse --info=inline --pointer="▶" \
             --border horizontal --color "border:dim" \
             --header "? help · esc quit" --color "header:green:italic:dim" \

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ gh notify [Flags]
 | Keys      | Description                                         |
 | --------- | --------------------------------------------------- |
 | ?         | toggle help                                         |
-| enter     | print notification and exit                         |
+| enter     | print notification, marked as read and exit         |
 | tab       | toggle preview notification                         |
 | shift+tab | change preview window size                          |
 | shift+↑↓  | scroll the preview up/ down                         |
@@ -44,6 +44,7 @@ gh notify [Flags]
 | ctrl+d    | view diff                                           |
 | ctrl+p    | view diff in patch format                           |
 | ctrl+r    | mark all displayed notifications as read and reload |
+| ctrl+t    | mark the selected notification as read and reload   |
 | ctrl+x    | write a comment with the editor and exit            |
 | esc       | exit                                                |
 

--- a/readme.md
+++ b/readme.md
@@ -33,20 +33,20 @@ gh notify [Flags]
 
 ### Key Bindings fzf
 
-| Keys      | Description                                         |
-| --------- | --------------------------------------------------- |
-| ?         | toggle help                                         |
-| enter     | print notification, marked as read and exit         |
-| tab       | toggle preview notification                         |
-| shift+tab | change preview window size                          |
-| shift+↑↓  | scroll the preview up/ down                         |
-| ctrl+b    | open notification in browser                        |
-| ctrl+d    | view diff                                           |
-| ctrl+p    | view diff in patch format                           |
-| ctrl+r    | mark all displayed notifications as read and reload |
-| ctrl+t    | mark the selected notification as read and reload   |
-| ctrl+x    | write a comment with the editor and exit            |
-| esc       | exit                                                |
+| Keys                           | Description                                         |
+| ------------------------------ | --------------------------------------------------- |
+| <kbd>?</kbd>                   | toggle help                                         |
+| <kbd>enter</kbd>               | print and mark the notification as read and quit    |
+| <kbd>tab</kbd>                 | toggle preview notification                         |
+| <kbd>shift</kbd><kbd>tab</kbd> | change preview window size                          |
+| <kbd>shift</kbd><kbd>↑↓</kbd>  | scroll the preview up/ down                         |
+| <kbd>ctrl</kbd><kbd>b</kbd>    | open notification in browser                        |
+| <kbd>ctrl</kbd><kbd>d</kbd>    | view diff                                           |
+| <kbd>ctrl</kbd><kbd>p</kbd>    | view diff in patch format                           |
+| <kbd>ctrl</kbd><kbd>r</kbd>    | mark all displayed notifications as read and reload |
+| <kbd>ctrl</kbd><kbd>t</kbd>    | mark notification as read and reload                |
+| <kbd>ctrl</kbd><kbd>x</kbd>    | write a comment with the editor and quit            |
+| <kbd>esc</kbd>                 | quit                                                |
 
 ---
 ## Customizations


### PR DESCRIPTION
### description
- fix #50
  - the `--template` formatting is replaced with `--jq` formatting, it allows to format the time to a ISO 8601 timestamp for marking notifications as `read` with <kbd>⌃ Control</kbd> + <kbd>R</kbd> even after the first reload and new notification appeared
- fix #51
  - allow the user to mark an individual notification as `read` with <kbd>⌃ Control</kbd> + <kbd>T</kbd>
  - the notification will also be marked as read, when the user hits  <kbd>⏎ Enter</kbd> on a selected notification
- feat, include the `latest_comment_url` and uses for `Issues/PR` to open the URL with <kbd>⌃ Control</kbd> + <kbd>B</kbd>
  - if no `latest_comment_url` has been found it will open the `Issues/PR` normally

<img src="https://github.com/meiji163/gh-notify/assets/92653266/e31e6255-a162-4b0b-be8b-cea95b40084e" width="600">


### todo
- [x] test if everything still works as expected
