### PR TITLE
fix: change grep function for release types

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -214,8 +214,8 @@ select_notif() {
     notif_msg="$1"
     # https://dandavison.github.io/delta
     diff_pager=$'if type -p delta >/dev/null; then delta --width ${FZF_PREVIEW_COLUMNS:-$COLUMNS}; else cat; fi'
-    open_notification_browser=$'unhashed_num=$(cut -d "#" -f2 <<<{9});if grep -q CheckSuite <<<{8}; then open https://github.com/{7}/actions ; elif grep -q Commit <<<{8}; then gh browse {9} -R {7} ; elif grep -q Discussion <<<{8}; then open https://github.com/{7}/discussions/{9} ; elif grep -qE "Issue|PullRequest" <<<{8}; then if grep -q null <<<{4} || test {4} = "$unhashed_num"; then gh issue view {9} -wR {7}; else open https://github.com/{7}/issues/${unhashed_num}#issuecomment-{4}; fi; elif grep -q "[Rr]elease" <<<{8}; then gh release view {9} -wR {7}; else gh repo view -w {7}; fi'
-    preview_notification='echo \[{5} {6} - {8}\] ;if grep -q Issue <<<{8}; then gh issue view {9} -R {7} --comments; elif grep -q PullRequest <<<\"{8}\"; then gh pr view {9} -R {7} --comments; elif grep -q "[Rr]elease" <<<{8}; then gh release view {9} -R {7}; else echo "Notification preview for {8} is not supported."; fi'
+    open_notification_browser=$'unhashed_num=$(cut -d "#" -f2 <<<{9});if grep -q CheckSuite <<<{8}; then open https://github.com/{7}/actions ; elif grep -q Commit <<<{8}; then gh browse {9} -R {7} ; elif grep -q Discussion <<<{8}; then open https://github.com/{7}/discussions/{9} ; elif grep -qE "Issue|PullRequest" <<<{8}; then if grep -q null <<<{4} || test {4} = "$unhashed_num"; then gh issue view {9} -wR {7}; else open https://github.com/{7}/issues/${unhashed_num}#issuecomment-{4}; fi; elif grep -qi "release" <<<{8}; then gh release view {9} -wR {7}; else gh repo view -w {7}; fi'
+    preview_notification='echo \[{5} {6} - {8}\] ;if grep -q Issue <<<{8}; then gh issue view {9} -R {7} --comments; elif grep -q PullRequest <<<\"{8}\"; then gh pr view {9} -R {7} --comments; elif grep -qi "release" <<<{8}; then gh release view {9} -R {7}; else echo "Notification preview for {8} is not supported."; fi'
     # If these were passed as a function to fzf, it would be called immediately when fzf is called, in spite of the fact that the assigned hotkey was not triggered.
     mark_all_read="gh api --silent --header $GH_REST_API_VERSION --method PUT notifications --raw-field last_read_at={1} --field read=true"
     mark_individual_read="if grep -q UNREAD <<<{3}; then gh api --silent --header $GH_REST_API_VERSION --method PATCH notifications/threads/{2}; fi"
@@ -254,7 +254,8 @@ select_notif() {
             gh issue view "$num" -R "$repo" --comments
         elif grep -q "PullRequest" <<<"$type"; then
             gh pr view "$num" -R "$repo" --comments
-        elif grep -q "[Rr]elease" <<<"$type"; then
+        elif grep -qi "release" <<<"$type"; then
+            # "type can be Release or Pre-release
             gh release view "$num" -R "$repo"
         else
             echo "Notification preview for $type is not supported."


### PR DESCRIPTION
#### description
- the `crate-ci/typos` is erroneously triggered by this string `[Rr]elease`
  - change the grep function will fix the issue
