### PR TITLE
fix: swap the 'open' command for 'python -m webbrowser'

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -290,15 +290,18 @@ if [[ -z "$notifs" ]]; then
     exit 0
 elif [[ $print_static_flag == "false" ]]; then
     if ! type -p fzf >/dev/null; then
-        echo "error: install \`fzf\` or use the -s flag" >&2
+        echo "error: install 'fzf' or use the -s flag" >&2
         exit 1
     fi
     USER_FZF_VERSION="$(fzf --version)"
     if [ "$(version $MIN_FZF_VERSION)" -gt "$(version "$USER_FZF_VERSION")" ]; then
-        echo "Error: \`fzf\` was found, but it is too old".
-        echo "Your \`fzf\` version is: $USER_FZF_VERSION".
-        echo "Minimum required \`fzf\` version is: $MIN_FZF_VERSION"
+        echo "Error: 'fzf' was found, but it is too old".
+        echo "Your 'fzf' version is: $USER_FZF_VERSION".
+        echo "Minimum required 'fzf' version is: $MIN_FZF_VERSION"
         exit 1
+    fi
+    if ! type -p python >/dev/null; then
+        echo "warning: 'python' was not found, it is recommended to install it, which is used to open some URLs with ctrl-b" >&2
     fi
     select_notif "$notifs"
 elif [[ $print_fzf_static_reload_flag == "true" ]]; then

--- a/gh-notify
+++ b/gh-notify
@@ -46,7 +46,7 @@ ${WHITE_BOLD}Key Bindings fzf${NC}
   ${GREEN}tab      ${NC}  toggle preview notification
   ${GREEN}shift+tab${NC}  change preview window size
   ${GREEN}shift+↑↓ ${NC}  scroll the preview up/ down
-  ${GREEN}ctrl+b   ${NC}  open notification in browser
+  ${GREEN}ctrl+b   ${NC}  open notification in the browser
   ${GREEN}ctrl+d   ${NC}  view diff
   ${GREEN}ctrl+p   ${NC}  view diff in patch format
   ${GREEN}ctrl+r   ${NC}  mark all displayed notifications as read and reload
@@ -214,7 +214,7 @@ select_notif() {
     notif_msg="$1"
     # https://dandavison.github.io/delta
     diff_pager=$'if type -p delta >/dev/null; then delta --width ${FZF_PREVIEW_COLUMNS:-$COLUMNS}; else cat; fi'
-    open_notification_browser=$'unhashed_num=$(cut -d "#" -f2 <<<{9});if grep -q CheckSuite <<<{8}; then open https://github.com/{7}/actions ; elif grep -q Commit <<<{8}; then gh browse {9} -R {7} ; elif grep -q Discussion <<<{8}; then open https://github.com/{7}/discussions/{9} ; elif grep -qE "Issue|PullRequest" <<<{8}; then if grep -q null <<<{4} || test {4} = "$unhashed_num"; then gh issue view {9} -wR {7}; else open https://github.com/{7}/issues/${unhashed_num}#issuecomment-{4}; fi; elif grep -qi "release" <<<{8}; then gh release view {9} -wR {7}; else gh repo view -w {7}; fi'
+    open_notification_browser=$'unhashed_num=$(cut -d "#" -f2 <<<{9});if grep -q CheckSuite <<<{8}; then python -m webbrowser https://github.com/{7}/actions ; elif grep -q Commit <<<{8}; then gh browse {9} -R {7} ; elif grep -q Discussion <<<{8}; then python -m webbrowser https://github.com/{7}/discussions/{9} ; elif grep -qE "Issue|PullRequest" <<<{8}; then if grep -q null <<<{4} || test {4} = "$unhashed_num"; then gh issue view {9} -wR {7}; else python -m webbrowser https://github.com/{7}/issues/${unhashed_num}#issuecomment-{4}; fi; elif grep -qi "release" <<<{8}; then gh release view {9} -wR {7}; else gh repo view -w {7}; fi'
     preview_notification='echo \[{5} {6} - {8}\] ;if grep -q Issue <<<{8}; then gh issue view {9} -R {7} --comments; elif grep -q PullRequest <<<\"{8}\"; then gh pr view {9} -R {7} --comments; elif grep -qi "release" <<<{8}; then gh release view {9} -R {7}; else echo "Notification preview for {8} is not supported."; fi'
     # If these were passed as a function to fzf, it would be called immediately when fzf is called, in spite of the fact that the assigned hotkey was not triggered.
     mark_all_read="gh api --silent --header $GH_REST_API_VERSION --method PUT notifications --raw-field last_read_at={1} --field read=true"

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ gh notify [Flags]
 | <kbd>tab</kbd>                 | toggle preview notification                         |
 | <kbd>shift</kbd><kbd>tab</kbd> | change preview window size                          |
 | <kbd>shift</kbd><kbd>↑↓</kbd>  | scroll the preview up/ down                         |
-| <kbd>ctrl</kbd><kbd>b</kbd>    | open notification in browser                        |
+| <kbd>ctrl</kbd><kbd>b</kbd>    | open notification in the browser                    |
 | <kbd>ctrl</kbd><kbd>d</kbd>    | view diff                                           |
 | <kbd>ctrl</kbd><kbd>p</kbd>    | view diff in patch format                           |
 | <kbd>ctrl</kbd><kbd>r</kbd>    | mark all displayed notifications as read and reload |
@@ -52,12 +52,12 @@ gh notify [Flags]
 ## Customizations
 
 ### Fuzzy Finder (fzf)
-Customize fzf colors and key bindings by exporting `ENVIRONMENT VARIABLES` to your `.zshrc`/`.bashrc`. See the man page (`man fzf`) for `AVAILABLE KEYS/ EVENTS` or [junegunn/fzf#environment-variables](https://github.com/junegunn/fzf#environment-variables) on GitHub for more details.
+Customize fzf key bindings by exporting `ENVIRONMENT VARIABLES` to your `.bashrc`/`.zshrc`. See the man page (`man fzf`) for `AVAILABLE KEYS/ EVENTS` or [junegunn/fzf#environment-variables](https://github.com/junegunn/fzf#environment-variables) on GitHub for more details.
 
 - NOTE: [How to use ALT commands in a terminal on macOS?](https://superuser.com/questions/496090/how-to-use-alt-commands-in-a-terminal-on-os-x)
 
-```zsh
-# ~/.zshrc
+```sh
+# ~/.bashrc or ~/.zshrc
 # The following examples allow you to clear the input query with alt+c,
 # jump to the first/last result with alt+u/d, refresh the preview window with alt+r
 # and scroll the preview in larger steps with ctrl+w/s.
@@ -69,9 +69,9 @@ export FZF_DEFAULT_OPTS="
 ```
 
 ### GitHub command line tool (gh)
-In the configuration file of the `gh` tool you can set your preferred editor. This is handy when you use the interactive mode to write a comment on a notification.
+In the configuration file of the `gh` tool you can set your preferred editor. This is handy when you use the <kbd>ctrl</kbd><kbd>x</kbd> hotkey to write a comment on a notification.
 
-```zsh
+```sh
 # See more details
 gh config
 # For example, set the editor to Visual Studio Code or Vim.


### PR DESCRIPTION
### description
- intended to fix #55
- `open` works only reliably under `macOS`, a cross-platform solution could be `python -m webbrowser`

#### TODO
- [ ] shall `python` be checked for existence
  - on Linux and macOS, Python is usually included by default
  -  windows ?
- [ ] discuss any ideas for a better solution to the issue?
