### PR TITLE
feat: (un)subscribe a URL

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -27,6 +27,7 @@ export NESTED_START_LVL="$SHLVL"
 export FINAL_MSG='All caught up!'
 # color codes
 export GREEN='\033[0;32m'
+export DARK_GRAY='\033[0;90m'
 export NC='\033[0m'
 export WHITE_BOLD='\033[1m'
 
@@ -50,6 +51,7 @@ ${WHITE_BOLD}Flags${NC}
   ${GREEN}-p    ${NC}  show only participating or mentioned notifications
   ${GREEN}-r    ${NC}  mark all notifications as read
   ${GREEN}-s    ${NC}  print a static display
+  ${GREEN}-u URL${NC}  (un)subscribe a URL, useful for issues/prs of interest
   ${GREEN}-w    ${NC}  display the preview window in interactive mode
 
 ${WHITE_BOLD}Key Bindings fzf${NC}
@@ -84,13 +86,13 @@ export preview_window_visibility='hidden'
 # not necessarily to be exported, since they are not used in any child process
 print_static_flag='false'
 mark_read_flag='false'
+update_subscription_url=''
 
-while getopts 'e:f:n:pawhsr' flag; do
+while getopts 'e:f:n:u:pawhsr' flag; do
     case "${flag}" in
     e) exclusion_string="${OPTARG}" ;;
     f) filter_string="${OPTARG}" ;;
-    n) num_notifications="${OPTARG}" ;;
-    p) only_participating_flag='true' ;;
+    u) update_subscription_url="${OPTARG}" ;;
     a) include_all_flag='true' ;;
     w) preview_window_visibility='nohidden' ;;
     s) print_static_flag='true' ;;
@@ -363,6 +365,45 @@ select_notif() {
 version() {
     awk <<<"$@" -F '.' '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'
 }
+
+if [[ -n "$update_subscription_url" ]]; then
+    graphql_query_resource=$'query ($url_input: URI!) {resource(url: $url_input) { ... on Subscribable { id viewerCanSubscribe viewerSubscription }}}'
+    IFS=$'\t' read -r node_id viewerCanSubscribe viewerSubscription < <(gh api graphql --raw-field url_input="$update_subscription_url" --raw-field query="$graphql_query_resource" \
+        --jq '.data.resource | [.id, .viewerCanSubscribe, .viewerSubscription] | @tsv') ||
+        { echo "Failed GraphQL URL resource query." >&2 && exit 1; }
+    if [[ -n "$node_id" ]]; then
+        if [[ $viewerSubscription == "UNSUBSCRIBED" && ! "$viewerCanSubscribe" ]]; then
+            echo "You are not allowed to subscribe to this URL."
+            exit 1
+        fi
+        case "$viewerSubscription" in
+        SUBSCRIBED)
+            updated_state="UNSUBSCRIBED"
+            update_text="Notifications for this URL have been turned off."
+            ;;
+        IGNORED | UNSUBSCRIBED)
+            updated_state="SUBSCRIBED"
+            update_text="Upon new updates you will receive notifications from this URL."
+            ;;
+        *)
+            echo "Error: No changes were made to the subscriptions."
+            echo "Returned value for current status is unknown: $viewerSubscription"
+            exit 1
+            ;;
+        esac
+        graphql_mutation_update_subscription=$'mutation ($updated_state: SubscriptionState!, $node_id: ID!) { updateSubscription(input: {state: $updated_state, subscribableId: $node_id}) { subscribable { viewerSubscription }}}'
+        gh api graphql --silent --raw-field updated_state="$updated_state" \
+            --raw-field node_id="$node_id" --raw-field query="$graphql_mutation_update_subscription" ||
+            { echo "Failed GraphQL mutation to update subscription status." >&2 && exit 1; }
+        echo
+        printf "%b%s%b: %b%s%b\n" "$GREEN" "$updated_state" "$NC" "$WHITE_BOLD" "$update_text" "$NC"
+        printf "%b%s%b\n" "$DARK_GRAY" "$update_subscription_url" "$NC"
+        exit 0
+    else
+        echo "The URL is invalid to subscribe to."
+        exit 1
+    fi
+fi
 
 gh_notify() {
     local notifs user_fzf_version

--- a/gh-notify
+++ b/gh-notify
@@ -368,11 +368,9 @@ version() {
 
 if [[ -n "$update_subscription_url" ]]; then
     graphql_query_resource=$'query ($url_input: URI!) {resource(url: $url_input) { ... on Subscribable { __typename id viewerCanSubscribe viewerSubscription }}}'
-    IFS=$'\t' read -r object_type node_id viewer_can_subscribe viewer_subscription < <(gh api graphql \
+    if IFS=$'\t' read -r object_type node_id viewer_can_subscribe viewer_subscription < <(gh api graphql \
         --raw-field url_input="$update_subscription_url" --raw-field query="$graphql_query_resource" \
-        --jq '.data.resource | map(.) | @tsv') ||
-        { echo "Failed GraphQL query for resource." >&2 && exit 1; }
-    if [[ -n "$node_id" ]]; then
+        --jq '.data.resource | map(.) | @tsv' 2>/dev/null); then
         if [[ $viewer_subscription != "SUBSCRIBED" && ! "$viewer_can_subscribe" ]]; then
             echo "You are not allowed to subscribe to this '$object_type'."
             exit 1
@@ -387,14 +385,13 @@ if [[ -n "$update_subscription_url" ]]; then
             update_text="Notifications enabled for this '$object_type'."
             ;;
         *)
-            echo "Error: No changes were made to the subscriptions."
-            echo "Returned value for current status is unknown: $viewer_subscription"
+            echo "ERROR: the queried value for the current status is unknown: $viewer_subscription"
             exit 1
             ;;
         esac
         graphql_mutation_update_subscription=$'mutation ($updated_state: SubscriptionState!, $node_id: ID!) { updateSubscription(input: {state: $updated_state, subscribableId: $node_id}) { subscribable { viewerSubscription }}}'
         # NOTE: For example, if you "UNSUBSCRIBE" from an Issue but you are still "SUBSCRIBED" to the Repository where the Issue resides, the Issue's subscription status is automatically set to "IGNORED" and can never be set to "UNSUBSCRIBED" as long as you are "SUBSCRIBED" to the Repository. This is a design decision by GitHub.
-        # enumValues for the SubscriptionState
+        # enumValues for the 'SubscriptionState'
         # "UNSUBSCRIBED" - "The User is only notified when participating or @mentioned."
         # "SUBSCRIBED" - "The User is notified of all conversations."
         # "IGNORED" - "The User is never notified."

--- a/gh-notify
+++ b/gh-notify
@@ -367,40 +367,52 @@ version() {
 }
 
 if [[ -n "$update_subscription_url" ]]; then
-    graphql_query_resource=$'query ($url_input: URI!) {resource(url: $url_input) { ... on Subscribable { id viewerCanSubscribe viewerSubscription }}}'
-    IFS=$'\t' read -r node_id viewerCanSubscribe viewerSubscription < <(gh api graphql --raw-field url_input="$update_subscription_url" --raw-field query="$graphql_query_resource" \
-        --jq '.data.resource | [.id, .viewerCanSubscribe, .viewerSubscription] | @tsv') ||
-        { echo "Failed GraphQL URL resource query." >&2 && exit 1; }
+    graphql_query_resource=$'query ($url_input: URI!) {resource(url: $url_input) { ... on Subscribable { __typename id viewerCanSubscribe viewerSubscription }}}'
+    IFS=$'\t' read -r object_type node_id viewer_can_subscribe viewer_subscription < <(gh api graphql \
+        --raw-field url_input="$update_subscription_url" --raw-field query="$graphql_query_resource" \
+        --jq '.data.resource | map(.) | @tsv') ||
+        { echo "Failed GraphQL query for resource." >&2 && exit 1; }
     if [[ -n "$node_id" ]]; then
-        if [[ $viewerSubscription == "UNSUBSCRIBED" && ! "$viewerCanSubscribe" ]]; then
-            echo "You are not allowed to subscribe to this URL."
+        if [[ $viewer_subscription != "SUBSCRIBED" && ! "$viewer_can_subscribe" ]]; then
+            echo "You are not allowed to subscribe to this '$object_type'."
             exit 1
         fi
-        case "$viewerSubscription" in
+        case "$viewer_subscription" in
         SUBSCRIBED)
             updated_state="UNSUBSCRIBED"
-            update_text="Notifications for this URL have been turned off."
+            update_text="Notifications disabled for this '$object_type'."
             ;;
         IGNORED | UNSUBSCRIBED)
             updated_state="SUBSCRIBED"
-            update_text="Upon new updates you will receive notifications from this URL."
+            update_text="Notifications enabled for this '$object_type'."
             ;;
         *)
             echo "Error: No changes were made to the subscriptions."
-            echo "Returned value for current status is unknown: $viewerSubscription"
+            echo "Returned value for current status is unknown: $viewer_subscription"
             exit 1
             ;;
         esac
         graphql_mutation_update_subscription=$'mutation ($updated_state: SubscriptionState!, $node_id: ID!) { updateSubscription(input: {state: $updated_state, subscribableId: $node_id}) { subscribable { viewerSubscription }}}'
-        gh api graphql --silent --raw-field updated_state="$updated_state" \
-            --raw-field node_id="$node_id" --raw-field query="$graphql_mutation_update_subscription" ||
-            { echo "Failed GraphQL mutation to update subscription status." >&2 && exit 1; }
-        echo
+        # NOTE: For example, if you "UNSUBSCRIBE" from an Issue but you are still "SUBSCRIBED" to the Repository where the Issue resides, the Issue's subscription status is automatically set to "IGNORED" and can never be set to "UNSUBSCRIBED" as long as you are "SUBSCRIBED" to the Repository. This is a design decision by GitHub.
+        # enumValues for the SubscriptionState
+        # "UNSUBSCRIBED" - "The User is only notified when participating or @mentioned."
+        # "SUBSCRIBED" - "The User is notified of all conversations."
+        # "IGNORED" - "The User is never notified."
+        updated_state=$(gh api graphql --raw-field updated_state="$updated_state" \
+            --raw-field node_id="$node_id" \
+            --raw-field query="$graphql_mutation_update_subscription" \
+            --jq '.data.updateSubscription.subscribable.viewerSubscription') ||
+            { echo "Failed GraphQL mutation to update the subscription status." >&2 && exit 1; }
+        echo "The list with all your subscriptions is only available via the Web UI."
+        printf "%bhttps://github.com/notifications/subscriptions%b\n\n" "$DARK_GRAY" "$NC"
         printf "%b%s%b: %b%s%b\n" "$GREEN" "$updated_state" "$NC" "$WHITE_BOLD" "$update_text" "$NC"
         printf "%b%s%b\n" "$DARK_GRAY" "$update_subscription_url" "$NC"
         exit 0
     else
-        echo "The URL is invalid to subscribe to."
+        possibleTypes=$(gh api graphql --raw-field query='{ __type(name: "Subscribable") { possibleTypes { name }}}' \
+            --jq '.data.__type.possibleTypes | map(.name) | join(", ")' ||
+            { echo "Failed GraphQL query for possibleTypes." >&2 && exit 1; })
+        printf "The URL is invalid to subscribe to.\nValid subscription types: %b%s%b\n" "$WHITE_BOLD" "$possibleTypes" "$NC"
         exit 1
     fi
 fi

--- a/gh-notify
+++ b/gh-notify
@@ -92,6 +92,8 @@ while getopts 'e:f:n:u:pawhsr' flag; do
     case "${flag}" in
     e) exclusion_string="${OPTARG}" ;;
     f) filter_string="${OPTARG}" ;;
+    n) num_notifications="${OPTARG}" ;;
+    p) only_participating_flag='true' ;;
     u) update_subscription_url="${OPTARG}" ;;
     a) include_all_flag='true' ;;
     w) preview_window_visibility='nohidden' ;;

--- a/readme.md
+++ b/readme.md
@@ -28,18 +28,19 @@ gh ext remove meiji163/gh-notify
 gh notify [Flags]
 ```
 
-| Flags    | Description                                             | Example                |
-| -------- | ------------------------------------------------------- | ---------------------- |
-| <none>   | show all unread notifications                           | `gh notify`            |
-| `-a`     | show all (read/ unread) notifications                   | `gh notify -a`         |
-| `-e`     | exclude notifications matching a string (REGEX support) | `gh notify -e "MyJob"` |
-| `-f`     | filter notifications matching a string (REGEX support)  | `gh notify -f "Repo"`  |
-| `-h`     | show the help page                                      | `gh notify -h`         |
-| `-n NUM` | max number of notifications to show                     | `gh notify -an 10`     |
-| `-p`     | show only participating or mentioned notifications      | `gh notify -ap`        |
-| `-r`     | mark all notifications as read                          | `gh notify -r`         |
-| `-s`     | print a static display                                  | `gh notify -an 10 -s`  |
-| `-w`     | display the preview window in interactive mode          | `gh notify -an 10 -w`  |
+| Flags    | Description                                             | Example                                              |
+| -------- | ------------------------------------------------------- | ---------------------------------------------------- |
+| <none>   | show all unread notifications                           | `gh notify`                                          |
+| `-a`     | show all (read/ unread) notifications                   | `gh notify -a`                                       |
+| `-e`     | exclude notifications matching a string (REGEX support) | `gh notify -e "MyJob"`                               |
+| `-f`     | filter notifications matching a string (REGEX support)  | `gh notify -f "Repo"`                                |
+| `-h`     | show the help page                                      | `gh notify -h`                                       |
+| `-n NUM` | max number of notifications to show                     | `gh notify -an 10`                                   |
+| `-p`     | show only participating or mentioned notifications      | `gh notify -ap`                                      |
+| `-r`     | mark all notifications as read                          | `gh notify -r`                                       |
+| `-s`     | print a static display                                  | `gh notify -an 10 -s`                                |
+| `-u URL` | (un)subscribe a URL, useful for issues/prs of interest  | `gh notify -u https://github.com/cli/cli/issues/659` |
+| `-w`     | display the preview window in interactive mode          | `gh notify -an 10 -w`                                |
 
 ### Key Bindings fzf
 


### PR DESCRIPTION
### description
- allow to (un)subscribe to a URL, this is particular useful when you want to get updates on an issue/pr, but don't want to `watch` the entire repo

- see demo
  - current setup toggles the subscription status, if you are `SUBSCRIBED` you get `UNSUBSCRIBED` and vice versa


<img src="https://raw.githubusercontent.com/LangLangbart/ImagePool/1b156858571bc6d3d82a26e318c0d67bc3f4a591/storage/2023-06-19_06-48-02_subscribe.gif" width="800">

#### TODO:
- [ ] check if it makes sense to add a hotkey to unsubscribe in interactive mode with `fzf`
  - it is advantageous to prefix notifications marked as `UNSUBSCRIBED` with an appropriate colored symbol
- [x] check if it makes sense to show a list of all subscriptions of a user
  - not possible, there is no API call to get the same list as seen in the Web UI
    - [github.com/notifications/subscriptions](https://github.com/notifications/subscriptions)
    - Ref: [GitHub community discussion: REST API notification list](https://github.com/orgs/community/discussions/54561) (5/May/23)
