### PR TITLE
refactor: 'ctrl-r' for reload and 'ctrl-a' for reload, mark all read and quit

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -385,8 +385,7 @@ gh_notify() {
             die "The minimum required 'fzf' version is $MIN_FZF_VERSION. Your 'fzf' version is: $user_fzf_version."
         fi
         if ! type -p python >/dev/null; then
-            echo "WARNING: 'Python' was not found"
-            echo "'Python' is used as a cross-platform solution for opening an URL in the browser." >&2
+            die "install 'Python' or use the -s flag"
         fi
         select_notif "$notifs"
     else

--- a/gh-notify
+++ b/gh-notify
@@ -237,8 +237,7 @@ open_in_browser() {
         python -m webbrowser "https://github.com/${repo}/discussions/${number}"
         ;;
     Issue | PullRequest)
-        if grep -q null <<<"$comment_number" ||
-            test "$comment_number" = "$unhashed_num"; then
+        if [[ "$comment_number" = "$unhashed_num" || "$comment_number" = null ]]; then
             gh issue view "$number" --web --repo "$repo"
         else
             python -m webbrowser "https://github.com/${repo}/issues/${unhashed_num}#issuecomment-${comment_number}"
@@ -358,7 +357,7 @@ select_notif() {
     esac
 }
 
-if [[ $mark_read_flag == "true" ]]; then
+if [ $mark_read_flag = "true" ]; then
     mark_all_read "" || die "Failed to mark notifications as read."
     echo "All notifications have been marked as read."
     exit 0
@@ -370,10 +369,10 @@ version() {
 }
 
 notifs="$(print_notifs)"
-if [[ -z "$notifs" ]]; then
+if [ -z "$notifs" ]; then
     echo "$FINAL_MSG"
     exit 0
-elif [[ $print_static_flag == "false" ]]; then
+elif [ $print_static_flag = "false" ]; then
     if ! type -p fzf >/dev/null; then
         die "install 'fzf' or use the -s flag"
     fi
@@ -383,7 +382,7 @@ elif [[ $print_static_flag == "false" ]]; then
     fi
     if ! type -p python >/dev/null; then
         echo "WARNING: 'Python' was not found"
-        echo "'Python' is used to open some URLs with 'ctrl-b'" >&2
+        echo "'Python' is used as a cross-platform solution for opening an URL in the browser." >&2
     fi
     select_notif "$notifs"
 else

--- a/gh-notify
+++ b/gh-notify
@@ -42,26 +42,27 @@ ${WHITE_BOLD}Usage${NC}
 ${WHITE_BOLD}Flags${NC}
   ${GREEN}<none>${NC}  show all unread notifications
   ${GREEN}-a    ${NC}  show all (read/ unread) notifications
-  ${GREEN}-r    ${NC}  mark all notifications as read
   ${GREEN}-e    ${NC}  exclude notifications matching a string (REGEX support)
   ${GREEN}-f    ${NC}  filter notifications matching a string (REGEX support)
-  ${GREEN}-s    ${NC}  print a static display
+  ${GREEN}-h    ${NC}  show the help page
   ${GREEN}-n NUM${NC}  max number of notifications to show
   ${GREEN}-p    ${NC}  show only participating or mentioned notifications
+  ${GREEN}-r    ${NC}  mark all notifications as read
+  ${GREEN}-s    ${NC}  print a static display
   ${GREEN}-w    ${NC}  display the preview window in interactive mode
-  ${GREEN}-h    ${NC}  show the help page
 
 ${WHITE_BOLD}Key Bindings fzf${NC}
   ${GREEN}?        ${NC}  toggle help
-  ${GREEN}enter    ${NC}  print and mark the notification as read and quit
-  ${GREEN}tab      ${NC}  toggle preview notification
-  ${GREEN}shift+tab${NC}  change preview window size
+  ${GREEN}enter    ${NC}  print the selected notification, mark it as read and quit
+  ${GREEN}tab      ${NC}  toggle notification preview
+  ${GREEN}shift+tab${NC}  resize the preview window
   ${GREEN}shift+↑↓ ${NC}  scroll the preview up/ down
-  ${GREEN}ctrl+b   ${NC}  open notification in the browser
+  ${GREEN}ctrl+a   ${NC}  mark all displayed notifications as read and reload
+  ${GREEN}ctrl+b   ${NC}  browser
   ${GREEN}ctrl+d   ${NC}  view diff
   ${GREEN}ctrl+p   ${NC}  view diff in patch format
-  ${GREEN}ctrl+r   ${NC}  mark all displayed notifications as read and reload
-  ${GREEN}ctrl+t   ${NC}  mark notification as read and reload
+  ${GREEN}ctrl+r   ${NC}  reload
+  ${GREEN}ctrl+t   ${NC}  mark the selected notification as read and reload
   ${GREEN}ctrl+x   ${NC}  write a comment with the editor and quit
   ${GREEN}esc      ${NC}  quit
 
@@ -313,10 +314,11 @@ select_notif() {
             --prompt "GitHub Notifications > " --color "prompt:80,info:40" \
             --bind "change:first" \
             --bind "?:toggle-preview+change-preview:print_help_text" \
+            --bind "ctrl-a:execute-silent(mark_all_read {})+reload:print_notifs || true" \
             --bind "ctrl-b:execute-silent:open_in_browser {}" \
             --bind "ctrl-d:toggle-preview+change-preview:if grep -q PullRequest <<<{8}; then gh pr diff {9} --repo {7}  | diff_pager; else view_notification {}; fi" \
             --bind "ctrl-p:toggle-preview+change-preview:if grep -q PullRequest <<<{8}; then gh pr diff {9} --patch --repo {7} | diff_pager; else view_notification {}; fi" \
-            --bind "ctrl-r:execute-silent(mark_all_read {})+reload:print_notifs || true" \
+            --bind "ctrl-r:reload:print_notifs || true" \
             --bind "ctrl-t:execute-silent(mark_individual_read {})+reload:print_notifs || true" \
             --bind "tab:toggle-preview+change-preview:view_notification {}" \
             --bind "btab:change-preview-window(75%:nohidden|75%:down:nohidden:border-top|nohidden)" \

--- a/gh-notify
+++ b/gh-notify
@@ -323,7 +323,7 @@ select_notif() {
             --bind "ctrl-t:execute-silent(mark_individual_read {})+reload:print_notifs || true" \
             --bind "tab:toggle-preview+change-preview:view_notification {}" \
             --bind "btab:change-preview-window(75%:nohidden|75%:down:nohidden:border-top|nohidden)" \
-            --preview-window wrap:"$preview_window_visibility":50%:right:border-left \
+            --preview-window "wrap:${preview_window_visibility}:50%:right:border-left" \
             --preview "view_notification {}" \
             --expect "enter,esc,ctrl-x"
     )

--- a/gh-notify
+++ b/gh-notify
@@ -99,7 +99,7 @@ while getopts 'e:f:n:pawhsr' flag; do
         exit 0
         ;;
     *)
-        die
+        die "see 'gh notify -h' for help"
         ;;
     esac
 done

--- a/gh-notify
+++ b/gh-notify
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# https://www.gnu.org/software/bash/manual/bash.html#The-Set-Builtin
 set -eo pipefail
 # The minimum fzf version that the user needs to run all interactive commands.
 MIN_FZF_VERSION="0.29.0"
@@ -105,6 +106,7 @@ while getopts 'e:f:n:pawhsr' flag; do
 done
 
 get_notifs() {
+    local page_num local_page_size
     page_num="${1:-1}"
     local_page_size=100
     if [ "$num_notifications" != "0" ]; then
@@ -148,7 +150,7 @@ get_notifs() {
 }
 
 print_notifs() {
-    local all_notifs page_num page new_notifs graphql_query_discussion
+    local all_notifs page_num page new_notifs graphql_query_discussion result
     all_notifs=''
     page_num=1
     graphql_query_discussion=$'query ($filter: String!) { search(query: $filter, type: DISCUSSION, first: 1) { nodes { ... on Discussion { number }}}}'
@@ -357,36 +359,41 @@ select_notif() {
     esac
 }
 
-if [ $mark_read_flag = "true" ]; then
-    mark_all_read "" || die "Failed to mark notifications as read."
-    echo "All notifications have been marked as read."
-    exit 0
-fi
-
 # for comparing multi-digit version numbers https://apple.stackexchange.com/a/123408/11374
 version() {
     awk <<<"$@" -F '.' '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'
 }
 
-notifs="$(print_notifs)"
-if [ -z "$notifs" ]; then
-    echo "$FINAL_MSG"
-    exit 0
-elif [ $print_static_flag = "false" ]; then
-    if ! type -p fzf >/dev/null; then
-        die "install 'fzf' or use the -s flag"
+gh_notify() {
+    local notifs user_fzf_version
+    if [ "$mark_read_flag" = "true" ]; then
+        mark_all_read "" || die "Failed to mark notifications as read."
+        echo "All notifications have been marked as read."
+        exit 0
     fi
-    USER_FZF_VERSION="$(fzf --version)"
-    if [ "$(version $MIN_FZF_VERSION)" -gt "$(version "$USER_FZF_VERSION")" ]; then
-        die "The minimum required 'fzf' version is $MIN_FZF_VERSION. Your 'fzf' version is: $USER_FZF_VERSION."
+
+    notifs="$(print_notifs)"
+    if [ -z "$notifs" ]; then
+        echo "$FINAL_MSG"
+        exit 0
+    elif [ $print_static_flag = "false" ]; then
+        if ! type -p fzf >/dev/null; then
+            die "install 'fzf' or use the -s flag"
+        fi
+        user_fzf_version="$(fzf --version)"
+        if [ "$(version $MIN_FZF_VERSION)" -gt "$(version "$user_fzf_version")" ]; then
+            die "The minimum required 'fzf' version is $MIN_FZF_VERSION. Your 'fzf' version is: $user_fzf_version."
+        fi
+        if ! type -p python >/dev/null; then
+            echo "WARNING: 'Python' was not found"
+            echo "'Python' is used as a cross-platform solution for opening an URL in the browser." >&2
+        fi
+        select_notif "$notifs"
+    else
+        # remove unimportant elements from the static display
+        # '[[:blank:]]' matches horizontal whitespace characters (spaces/ tabs)
+        echo "$notifs" | sed -E 's/^([^[:blank:]]+[[:blank:]]+){4}//'
     fi
-    if ! type -p python >/dev/null; then
-        echo "WARNING: 'Python' was not found"
-        echo "'Python' is used as a cross-platform solution for opening an URL in the browser." >&2
-    fi
-    select_notif "$notifs"
-else
-    # remove unimportant elements from the static display
-    # '[[:blank:]]' matches horizontal whitespace characters (spaces/ tabs)
-    echo "$notifs" | sed -E 's/^([^[:blank:]]+[[:blank:]]+){4}//'
-fi
+}
+
+gh_notify

--- a/readme.md
+++ b/readme.md
@@ -30,31 +30,32 @@ gh notify [Flags]
 | -------- | ------------------------------------------------------- | ---------------------- |
 | <none>   | show all unread notifications                           | `gh notify`            |
 | `-a`     | show all (read/ unread) notifications                   | `gh notify -a`         |
-| `-r`     | mark all notifications as read                          | `gh notify -r`         |
 | `-e`     | exclude notifications matching a string (REGEX support) | `gh notify -e "MyJob"` |
 | `-f`     | filter notifications matching a string (REGEX support)  | `gh notify -f "Repo"`  |
-| `-s`     | print a static display                                  | `gh notify -as`        |
+| `-h`     | show the help page                                      | `gh notify -h`         |
 | `-n NUM` | max number of notifications to show                     | `gh notify -an 10`     |
 | `-p`     | show only participating or mentioned notifications      | `gh notify -ap`        |
+| `-r`     | mark all notifications as read                          | `gh notify -r`         |
+| `-s`     | print a static display                                  | `gh notify -as`        |
 | `-w`     | display the preview window in interactive mode          | `gh notify -an 10 -w`  |
-| `-h`     | show the help page                                      | `gh notify -h`         |
 
 ### Key Bindings fzf
 
-| Keys                           | Description                                         |
-| ------------------------------ | --------------------------------------------------- |
-| <kbd>?</kbd>                   | toggle help                                         |
-| <kbd>enter</kbd>               | print and mark the notification as read and quit    |
-| <kbd>tab</kbd>                 | toggle preview notification                         |
-| <kbd>shift</kbd><kbd>tab</kbd> | change preview window size                          |
-| <kbd>shift</kbd><kbd>↑↓</kbd>  | scroll the preview up/ down                         |
-| <kbd>ctrl</kbd><kbd>b</kbd>    | open notification in the browser                    |
-| <kbd>ctrl</kbd><kbd>d</kbd>    | view diff                                           |
-| <kbd>ctrl</kbd><kbd>p</kbd>    | view diff in patch format                           |
-| <kbd>ctrl</kbd><kbd>r</kbd>    | mark all displayed notifications as read and reload |
-| <kbd>ctrl</kbd><kbd>t</kbd>    | mark notification as read and reload                |
-| <kbd>ctrl</kbd><kbd>x</kbd>    | write a comment with the editor and quit            |
-| <kbd>esc</kbd>                 | quit                                                |
+| Keys                           | Description                                               |
+| ------------------------------ | --------------------------------------------------------- |
+| <kbd>?</kbd>                   | toggle help                                               |
+| <kbd>enter</kbd>               | print the selected notification, mark it as read and quit |
+| <kbd>tab</kbd>                 | toggle notification preview                               |
+| <kbd>shift</kbd><kbd>tab</kbd> | resize the preview window                                 |
+| <kbd>shift</kbd><kbd>↑↓</kbd>  | scroll the preview up/ down                               |
+| <kbd>ctrl</kbd><kbd>a</kbd>    | mark all displayed notifications as read and reload       |
+| <kbd>ctrl</kbd><kbd>b</kbd>    | browser                                                   |
+| <kbd>ctrl</kbd><kbd>d</kbd>    | view diff                                                 |
+| <kbd>ctrl</kbd><kbd>p</kbd>    | view diff in patch format                                 |
+| <kbd>ctrl</kbd><kbd>r</kbd>    | reload                                                    |
+| <kbd>ctrl</kbd><kbd>t</kbd>    | mark the selected notification as read and reload         |
+| <kbd>ctrl</kbd><kbd>x</kbd>    | write a comment with the editor and quit                  |
+| <kbd>esc</kbd>                 | quit                                                      |
 
 ---
 ## Customizations

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,9 @@ gh ext upgrade meiji163/gh-notify
 gh ext remove meiji163/gh-notify
 ```
 
-Install the [Fuzzy Finder (fzf)](https://github.com/junegunn/fzf#installation) for interactive mode.
+- to use `gh notify` interactively also install these tools
+  - [Fuzzy Finder (fzf)](https://github.com/junegunn/fzf#installation)
+  - [Python](https://www.python.org/) in cases where `gh` can't open the `URL` in your browser, this oneliner is used as a cross-platform solution: `python -m webbrowser <URL>`
 
 ## Usage
 

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ gh notify [Flags]
 | `-n NUM` | max number of notifications to show                     | `gh notify -an 10`     |
 | `-p`     | show only participating or mentioned notifications      | `gh notify -ap`        |
 | `-r`     | mark all notifications as read                          | `gh notify -r`         |
-| `-s`     | print a static display                                  | `gh notify -as`        |
+| `-s`     | print a static display                                  | `gh notify -an 10 -s`  |
 | `-w`     | display the preview window in interactive mode          | `gh notify -an 10 -w`  |
 
 ### Key Bindings fzf


### PR DESCRIPTION
### description
- the <kbd>⌃ Control</kbd> + <kbd>r</kbd> hotkey should really only `reload` the notifications, as this is a typical behavior from the browser
  - adding <kbd>⌃ Control</kbd> + <kbd>a</kbd> for marking all notifications as read
  - Ref: check the commit on the fork [dcrblack/gh-notify](https://github.com/dcrblack/gh-notify/commit/a560fc4b92473d77325b9c41e353e27d532fa5ba)
