### PR TITLE
fix: nested level

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -23,6 +23,8 @@ die() {
 
 # 'SHLVL' variable represents the nesting level of the current shell
 export NESTED_START_LVL="$SHLVL"
+export FINAL_MSG='All caught up!'
+# color codes
 export GREEN='\033[0;32m'
 export NC='\033[0m'
 export WHITE_BOLD='\033[1m'
@@ -201,7 +203,7 @@ print_notifs() {
         # it does work with '--bind "zero:become:"', but this only came with version '0.40.0'
         # workaround, since fzf hides the first elements with '--with-nth 5..'
         # if the list is empty on a reload, the message would be hidden, so ' \b' (backspace) is added
-        echo -e ' \b \b \b \bAll caught up!'
+        echo -e " \b \b \b \b$FINAL_MSG"
     else
         echo "$result"
     fi
@@ -367,7 +369,7 @@ version() {
 
 notifs="$(print_notifs)"
 if [[ -z "$notifs" ]]; then
-    echo "All caught up!"
+    echo "$FINAL_MSG"
     exit 0
 elif [[ $print_static_flag == "false" ]]; then
     if ! type -p fzf >/dev/null; then

--- a/gh-notify
+++ b/gh-notify
@@ -21,6 +21,8 @@ die() {
     exit 1
 }
 
+# 'SHLVL' variable represents the nesting level of the current shell
+export NESTED_START_LVL="$SHLVL"
 export GREEN='\033[0;32m'
 export NC='\033[0m'
 export WHITE_BOLD='\033[1m'
@@ -193,9 +195,8 @@ print_notifs() {
     echo >&2 -e "\r\033[K"
 
     result=$(echo "$all_notifs" | grep -v "$exclusion_string" | grep "$filter_string" | column -ts $'\t')
-    # 'SHLVL' variable represents the nesting level of the current shell
-    # if its larger than 2, we assume to be in the 'fzf' reload function
-    if [[ -z "$result" && "$SHLVL" -gt 2 ]]; then
+    # if the value is greater than the initial start value, we assume to be in the 'fzf’ reload function
+    if [[ -z "$result" && "$SHLVL" -gt "$NESTED_START_LVL" ]]; then
         # TODO: exit fzf automatically if the list is empty after a reload
         # it does work with '--bind "zero:become:"', but this only came with version '0.40.0'
         # workaround, since fzf hides the first elements with '--with-nth 5..'


### PR DESCRIPTION
#### description
- Follow-up to #62 to display the message correctly when `fzf` is reloaded and the list is empty
