### PR TITLE
chore: display the local timestamp in the list - strflocaltime

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -142,7 +142,7 @@ get_notifs() {
             thread_id: .id,
             thread_state: (if .unread then "UNREAD" else "READ" end),
             comment_url: .subject.latest_comment_url | tostring | split("/") | last,
-            timefmt: colored(.updated_at | fromdateiso8601 | strftime("%d/%b %H:%M"); "gray"),
+            timefmt: colored(.updated_at | fromdateiso8601 | strflocaltime("%d/%b %H:%M"); "gray"),
             owner: colored(.repository.owner.login; "cyan"),
             name: colored(.repository.name; "cyan_bold"),
             type: .subject.type,


### PR DESCRIPTION
### description
- use 'strflocaltime' for the timestamp instead of 'strftime'

```sh
man jq
...
# The strftime(fmt) builtin formats a time (GMT) with the given format. The strflocaltime does
# the same, but using the local timezone setting. 
```
