### PR TITLE
chore: alternative SIZE_THRESHOLD preview

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -327,7 +327,7 @@ select_notif() {
             --bind "ctrl-t:execute-silent(mark_individual_read {})+reload:print_notifs || true" \
             --bind "tab:toggle-preview+change-preview:view_notification {}" \
             --bind "btab:change-preview-window(75%:nohidden|75%:down:nohidden:border-top|nohidden)" \
-            --preview-window "wrap:${preview_window_visibility}:50%:right:border-left" \
+            --preview-window "wrap:${preview_window_visibility}:50%:right:border-left:<65(wrap:${preview_window_visibility}:75%:down:border-top)" \
             --preview "view_notification {}" \
             --expect "enter,esc,ctrl-x"
     )


### PR DESCRIPTION
### description
- add an alternative preview window for small windows

```sh
man fzf
* You can specify an alternative set of options that are used only when the size
  of the preview window is below a certain threshold. Note that only one
  alternative layout is allowed.
 
 e.g.
  fzf --preview 'cat {}' --preview-window 'right,border-left,<30(up,30%,border-bottom)'
```
