### PR TITLE
feat: use the 'less' pager with the 'enter' key

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -258,17 +258,15 @@ open_in_browser() {
 
 view_notification() {
     local all_comments date time repo type number
-    # if 'all_comments' exists and isn't null, use the '--comments' flag
-    case "$1" in
-        --all_comments)
-            shift
-            all_comments="1"
-            ;;
-    esac
+    if [ "$1" = "--all_comments" ]; then
+        shift
+        all_comments="1"
+    fi
     IFS=' ' read -r _ _ _ _ date time repo type number _ <<<"$1"
     printf "[%s %s - %s]\n" "$date" "$time" "$type"
     case "$type" in
         Issue)
+            # use the '--comments' flag only if 'all_comments' exists and is not null
             gh issue view "$number" --repo "$repo" ${all_comments:+"--comments"}
             ;;
         PullRequest)
@@ -294,7 +292,7 @@ mark_all_read() {
 mark_individual_read() {
     local thread_id thread_state
     IFS=' ' read -r _ thread_id thread_state _ <<<"$1"
-    if [ "$thread_state" = UNREAD ]; then
+    if [ "$thread_state" = "UNREAD" ]; then
         gh api --silent --header "$GH_REST_API_VERSION" --method PATCH "notifications/threads/${thread_id}"
     fi
 }
@@ -316,7 +314,7 @@ select_notif() {
         "--status-column"     # mark matched lines on the left side
         "--tilde"             # don't show '~' symbols on lines after EOF
     )
-    if [[ $(version "$(less --version | sed -E 's/^[^0-9]*//;q')") -ge 550 ]]; then
+    if [[ -z $(check_version less 550 echo) ]]; then
         # https://www.greenwoodsoftware.com/less/old.html
         # mouse input came with version 550
         less_args+=("--mouse")
@@ -387,61 +385,75 @@ select_notif() {
     esac
 }
 
-# for comparing multi-digit version numbers https://apple.stackexchange.com/a/123408/11374
-version() {
-    awk <<<"$@" -F '.' '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'
+# This function validates the version of a tool.
+check_version() {
+    local tool=$1 threshold=$2 on_error=${3:-die}
+    local user_version
+    declare -a ver_parts threshold_parts
+    user_version=$($tool --version 2>&1 | grep -Eo '[0-9]+(\.[0-9]+)*' | sed q)
+
+    IFS='.' read -ra ver_parts <<<"$user_version"
+    IFS='.' read -ra threshold_parts <<<"$threshold"
+
+    for i in "${!ver_parts[@]}"; do
+        if (("${ver_parts[i]}" < "${threshold_parts[i]}")); then
+            $on_error "Your 'fzf' version '$user_version' is insufficient. The minimum required version is '$threshold'."
+        fi
+    done
 }
 
-if [[ -n $update_subscription_url ]]; then
-    graphql_query_resource=$'query ($url_input: URI!) {resource(url: $url_input) { ... on Subscribable { __typename id viewerCanSubscribe viewerSubscription }}}'
-    if IFS=$'\t' read -r object_type node_id viewer_can_subscribe viewer_subscription < <(gh api graphql \
-        --raw-field url_input="$update_subscription_url" --raw-field query="$graphql_query_resource" \
-        --jq '.data.resource | map(.) | @tsv' 2>/dev/null); then
-        if [[ $viewer_subscription != "SUBSCRIBED" && ! $viewer_can_subscribe ]]; then
-            echo "You are not allowed to subscribe to this '$object_type'."
+gh_notify() {
+    local graphql_query_resource updated_state update_text
+    local graphql_mutation_update_subscription possibleTypes notifs
+    if [[ -n $update_subscription_url ]]; then
+        graphql_query_resource=$'query ($url_input: URI!) {resource(url: $url_input) { ... on Subscribable { __typename id viewerCanSubscribe viewerSubscription }}}'
+        if IFS=$'\t' read -r object_type node_id viewer_can_subscribe viewer_subscription < <(gh api graphql \
+            --raw-field url_input="$update_subscription_url" --raw-field query="$graphql_query_resource" \
+            --jq '.data.resource | map(.) | @tsv' 2>/dev/null); then
+            if [[ $viewer_subscription != "SUBSCRIBED" && ! $viewer_can_subscribe ]]; then
+                die "You are not allowed to subscribe to this '$object_type'."
+            fi
+            case "$viewer_subscription" in
+                SUBSCRIBED)
+                    updated_state="UNSUBSCRIBED"
+                    update_text="Notifications disabled for this '$object_type'."
+                    ;;
+                IGNORED | UNSUBSCRIBED)
+                    updated_state="SUBSCRIBED"
+                    update_text="Notifications enabled for this '$object_type'."
+                    ;;
+                *)
+                    die "ERROR: the queried value for the current status is unknown: $viewer_subscription"
+                    ;;
+            esac
+            graphql_mutation_update_subscription=$'mutation ($updated_state: SubscriptionState!, $node_id: ID!) { updateSubscription(input: {state: $updated_state, subscribableId: $node_id}) { subscribable { viewerSubscription }}}'
+            # NOTE: For example, if you "UNSUBSCRIBE" from an Issue but you are still
+            # "SUBSCRIBED" to the Repository where the Issue resides, the Issue's
+            # subscription status is automatically set to "IGNORED" and can never be set
+            # to "UNSUBSCRIBED" as long as you are "SUBSCRIBED" to the Repository. This is
+            # a design decision by GitHub. The enumValues for the 'SubscriptionState' are:
+            # "UNSUBSCRIBED" - "The User is only notified when participating or @mentioned."
+            # "SUBSCRIBED" - "The User is notified of all conversations."
+            # "IGNORED" - "The User is never notified."
+            updated_state=$(gh api graphql --raw-field updated_state="$updated_state" \
+                --raw-field node_id="$node_id" \
+                --raw-field query="$graphql_mutation_update_subscription" \
+                --jq '.data.updateSubscription.subscribable.viewerSubscription') ||
+                die "Failed GraphQL mutation to update the subscription status."
+            echo "The list with all your subscriptions is only available via the Web UI."
+            printf "%bhttps://github.com/notifications/subscriptions%b\n\n" "$DARK_GRAY" "$NC"
+            printf "%b%s%b: %b%s%b\n" "$GREEN" "$updated_state" "$NC" "$WHITE_BOLD" "$update_text" "$NC"
+            printf "%b%s%b\n" "$DARK_GRAY" "$update_subscription_url" "$NC"
+            exit 0
+        else
+            possibleTypes=$(gh api graphql --raw-field query='{ __type(name: "Subscribable") { possibleTypes { name }}}' \
+                --jq '.data.__type.possibleTypes | map(.name) | join(", ")' ||
+                die "Failed GraphQL query for possibleTypes.")
+            printf "The URL is invalid to subscribe to.\nValid subscription types: %b%s%b\n" "$WHITE_BOLD" "$possibleTypes" "$NC"
             exit 1
         fi
-        case "$viewer_subscription" in
-            SUBSCRIBED)
-                updated_state="UNSUBSCRIBED"
-                update_text="Notifications disabled for this '$object_type'."
-                ;;
-            IGNORED | UNSUBSCRIBED)
-                updated_state="SUBSCRIBED"
-                update_text="Notifications enabled for this '$object_type'."
-                ;;
-            *)
-                echo "ERROR: the queried value for the current status is unknown: $viewer_subscription"
-                exit 1
-                ;;
-        esac
-        graphql_mutation_update_subscription=$'mutation ($updated_state: SubscriptionState!, $node_id: ID!) { updateSubscription(input: {state: $updated_state, subscribableId: $node_id}) { subscribable { viewerSubscription }}}'
-        # NOTE: For example, if you "UNSUBSCRIBE" from an Issue but you are still "SUBSCRIBED" to the Repository where the Issue resides, the Issue's subscription status is automatically set to "IGNORED" and can never be set to "UNSUBSCRIBED" as long as you are "SUBSCRIBED" to the Repository. This is a design decision by GitHub.
-        # enumValues for the 'SubscriptionState'
-        # "UNSUBSCRIBED" - "The User is only notified when participating or @mentioned."
-        # "SUBSCRIBED" - "The User is notified of all conversations."
-        # "IGNORED" - "The User is never notified."
-        updated_state=$(gh api graphql --raw-field updated_state="$updated_state" \
-            --raw-field node_id="$node_id" \
-            --raw-field query="$graphql_mutation_update_subscription" \
-            --jq '.data.updateSubscription.subscribable.viewerSubscription') ||
-            { echo "Failed GraphQL mutation to update the subscription status." >&2 && exit 1; }
-        echo "The list with all your subscriptions is only available via the Web UI."
-        printf "%bhttps://github.com/notifications/subscriptions%b\n\n" "$DARK_GRAY" "$NC"
-        printf "%b%s%b: %b%s%b\n" "$GREEN" "$updated_state" "$NC" "$WHITE_BOLD" "$update_text" "$NC"
-        printf "%b%s%b\n" "$DARK_GRAY" "$update_subscription_url" "$NC"
-        exit 0
-    else
-        possibleTypes=$(gh api graphql --raw-field query='{ __type(name: "Subscribable") { possibleTypes { name }}}' \
-            --jq '.data.__type.possibleTypes | map(.name) | join(", ")' ||
-            { echo "Failed GraphQL query for possibleTypes." >&2 && exit 1; })
-        printf "The URL is invalid to subscribe to.\nValid subscription types: %b%s%b\n" "$WHITE_BOLD" "$possibleTypes" "$NC"
-        exit 1
     fi
-fi
 
-gh_notify() {
-    local notifs user_fzf_version
     if [ "$mark_read_flag" = "true" ]; then
         mark_all_read "" || die "Failed to mark notifications as read."
         echo "All notifications have been marked as read."
@@ -458,10 +470,7 @@ gh_notify() {
                 die "install '$tool' or use the -s flag"
             fi
         done
-        user_fzf_version="$(fzf --version)"
-        if [ "$(version $MIN_FZF_VERSION)" -gt "$(version "$user_fzf_version")" ]; then
-            die "The minimum required 'fzf' version is $MIN_FZF_VERSION. Your 'fzf' version is: $user_fzf_version."
-        fi
+        check_version fzf "$MIN_FZF_VERSION"
         select_notif "$notifs"
     else
         # remove unimportant elements from the static display

--- a/gh-notify
+++ b/gh-notify
@@ -312,8 +312,8 @@ select_notif() {
         "--hilite-search"     # Highlight results when searching with slash key (/)
         "--jump-target=.3"    # percent on the screen for the target line
         "--quiet"             # be more quiet
-        "--quit-on-intr"      # quit less immediately with ^C
         "--RAW-CONTROL-CHARS" # colors will not work without it
+        "--status-column"     # mark matched lines on the left side
         "--tilde"             # don't show '~' symbols on lines after EOF
     )
     if [[ $(version "$(less --version | sed -E 's/^[^0-9]*//;q')") -ge 550 ]]; then

--- a/gh-notify
+++ b/gh-notify
@@ -453,15 +453,14 @@ gh_notify() {
         echo "$FINAL_MSG"
         exit 0
     elif [ $print_static_flag = "false" ]; then
-        if ! type -p fzf >/dev/null; then
-            die "install 'fzf' or use the -s flag"
-        fi
+        for tool in less python fzf; do
+            if ! type -p $tool >/dev/null; then
+                die "install '$tool' or use the -s flag"
+            fi
+        done
         user_fzf_version="$(fzf --version)"
         if [ "$(version $MIN_FZF_VERSION)" -gt "$(version "$user_fzf_version")" ]; then
             die "The minimum required 'fzf' version is $MIN_FZF_VERSION. Your 'fzf' version is: $user_fzf_version."
-        fi
-        if ! type -p python >/dev/null; then
-            die "install 'Python' or use the -s flag"
         fi
         select_notif "$notifs"
     else

--- a/gh-notify
+++ b/gh-notify
@@ -397,7 +397,7 @@ check_version() {
 
     for i in "${!ver_parts[@]}"; do
         if (("${ver_parts[i]}" < "${threshold_parts[i]}")); then
-            $on_error "Your 'fzf' version '$user_version' is insufficient. The minimum required version is '$threshold'."
+            $on_error "Your '$tool' version '$user_version' is insufficient. The minimum required version is '$threshold'."
         fi
     done
 }

--- a/gh-notify
+++ b/gh-notify
@@ -305,9 +305,9 @@ select_notif() {
     # '-F/--quit-if-one-screen' option. The screen will not stay open for small
     # text files that fit on the entire screen. The easiest solution is to
     # disable the 'LESS' variable and define common sense options.
-
     [[ -n $LESS ]] && unset LESS
     less_args=(
+        "--clear-screen"      # painted from the top line down
         "--LONG-PROMPT"       # Long prompts ("Line X of Y")
         "--hilite-search"     # Highlight results when searching with slash key (/)
         "--jump-target=.3"    # percent on the screen for the target line
@@ -316,7 +316,7 @@ select_notif() {
         "--RAW-CONTROL-CHARS" # colors will not work without it
         "--tilde"             # don't show '~' symbols on lines after EOF
     )
-    if [[ $(version "$(less --version | sed -E 's/^[^0-9]*//' | sed q)") -ge 550 ]]; then
+    if [[ $(version "$(less --version | sed -E 's/^[^0-9]*//;q')") -ge 550 ]]; then
         # https://www.greenwoodsoftware.com/less/old.html
         # mouse input came with version 550
         less_args+=("--mouse")

--- a/gh-notify
+++ b/gh-notify
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
+set -o errexit -o nounset -o pipefail
 # https://www.gnu.org/software/bash/manual/bash.html#The-Set-Builtin
-set -eo pipefail
+
 # The minimum fzf version that the user needs to run all interactive commands.
 MIN_FZF_VERSION="0.29.0"
 
@@ -199,7 +200,7 @@ print_notifs() {
         [[ $num_notifications != "0" ]] && break
     done
     # clear the dots we printed
-    echo >&2 -e "\r\033[K"
+    echo >&2 -ne "\r\033[K"
 
     result=$(echo "$all_notifs" | grep -v "$exclusion_string" | grep "$filter_string" | column -ts $'\t')
     # if the value is greater than the initial start value, we assume to be in the 'fzf’ reload function

--- a/gh-notify
+++ b/gh-notify
@@ -8,9 +8,7 @@ MIN_FZF_VERSION="0.29.0"
 # https://docs.github.com/en/rest/overview/api-versions
 export GH_REST_API_VERSION="X-GitHub-Api-Version:2022-11-28"
 # Enable terminal-style output even when the output is redirected.
-export GH_FORCE_TTY=100%
-# Disable the gh pager
-export GH_PAGER="cat"
+export GH_FORCE_TTY=1
 
 # NotificationReason:
 # assign, author, comment, invitation, manual, mention, review_requested, security_alert, state_change, subscribed, team_mention, ci_activity
@@ -56,7 +54,7 @@ ${WHITE_BOLD}Flags${NC}
 
 ${WHITE_BOLD}Key Bindings fzf${NC}
   ${GREEN}?        ${NC}  toggle help
-  ${GREEN}enter    ${NC}  print the selected notification, mark it as read and quit
+  ${GREEN}enter    ${NC}  view the selected notification in the 'less' pager
   ${GREEN}tab      ${NC}  toggle notification preview
   ${GREEN}shift+tab${NC}  resize the preview window
   ${GREEN}shift+↑↓ ${NC}  scroll the preview up/ down
@@ -259,15 +257,22 @@ open_in_browser() {
 }
 
 view_notification() {
-    local date time repo type number
+    local all_comments date time repo type number
+    # if 'all_comments' exists and isn't null, use the '--comments' flag
+    case "$1" in
+        --all_comments)
+            shift
+            all_comments="1"
+            ;;
+    esac
     IFS=' ' read -r _ _ _ _ date time repo type number _ <<<"$1"
     printf "[%s %s - %s]\n" "$date" "$time" "$type"
     case "$type" in
         Issue)
-            gh issue view "$number" --repo "$repo" --comments
+            gh issue view "$number" --repo "$repo" ${all_comments:+"--comments"}
             ;;
         PullRequest)
-            gh pr view "$number" --repo "$repo" --comments
+            gh pr view "$number" --repo "$repo" ${all_comments:+"--comments"}
             ;;
         Pre-release | Release)
             gh release view "$number" --repo "$repo"
@@ -295,6 +300,28 @@ mark_individual_read() {
 }
 
 select_notif() {
+    declare -a less_args
+    # If the user has assigned the LESS environment variable with the
+    # '-F/--quit-if-one-screen' option. The screen will not stay open for small
+    # text files that fit on the entire screen. The easiest solution is to
+    # disable the 'LESS' variable and define common sense options.
+
+    [[ -n $LESS ]] && unset LESS
+    less_args=(
+        "--LONG-PROMPT"       # Long prompts ("Line X of Y")
+        "--hilite-search"     # Highlight results when searching with slash key (/)
+        "--jump-target=.3"    # percent on the screen for the target line
+        "--quiet"             # be more quiet
+        "--quit-on-intr"      # quit less immediately with ^C
+        "--RAW-CONTROL-CHARS" # colors will not work without it
+        "--tilde"             # don't show '~' symbols on lines after EOF
+    )
+    if [[ $(version "$(less --version | sed -E 's/^[^0-9]*//' | sed q)") -ge 550 ]]; then
+        # https://www.greenwoodsoftware.com/less/old.html
+        # mouse input came with version 550
+        less_args+=("--mouse")
+    fi
+
     local output expected_key selected_line repo type num
     # make functions available in child processes
     # 'SHELL="$(which bash)"' is needed to use exported functions when the default shell
@@ -325,11 +352,12 @@ select_notif() {
             --bind "ctrl-p:toggle-preview+change-preview:if grep -q PullRequest <<<{8}; then gh pr diff {9} --patch --repo {7} | diff_pager; else view_notification {}; fi" \
             --bind "ctrl-r:reload:print_notifs || true" \
             --bind "ctrl-t:execute-silent(mark_individual_read {})+reload:print_notifs || true" \
+            --bind "enter:execute:view_notification --all_comments {} | less ${less_args[*]} >/dev/tty" \
             --bind "tab:toggle-preview+change-preview:view_notification {}" \
             --bind "btab:change-preview-window(75%:nohidden|75%:down:nohidden:border-top|nohidden)" \
             --preview-window "wrap:${preview_window_visibility}:50%:right:border-left:<65(wrap:${preview_window_visibility}:75%:down:border-top)" \
             --preview "view_notification {}" \
-            --expect "enter,esc,ctrl-x"
+            --expect "esc,ctrl-x"
     )
     # actions that close fzf are defined below
     # 1st line ('--print-query'): the input query string
@@ -340,10 +368,6 @@ select_notif() {
     IFS=' ' read -r _ thread_id thread_state _ _ _ repo type num _ <<<"$selected_line"
     [[ -z $type ]] && exit 0
     case "$expected_key" in
-        enter)
-            view_notification "$selected_line" || die "Failed to view notification."
-            mark_individual_read "$selected_line" || die "Failed to mark the notification as read."
-            ;;
         esc)
             # quit with exit code 0; 'fzf' returns 130
             # TODO: when updating to '0.38.0' use '--bind "esc:become:"'

--- a/gh-notify
+++ b/gh-notify
@@ -2,6 +2,17 @@
 set -o errexit -o nounset -o pipefail
 # https://www.gnu.org/software/bash/manual/bash.html#The-Set-Builtin
 
+# ====================== Infos =======================
+
+# https://docs.github.com/en/rest/activity/notifications
+# NotificationReason:
+# assign, author, comment, invitation, manual, mention, review_requested, security_alert, state_change, subscribed, team_mention, ci_activity
+# NotificationSubjectTypes:
+# CheckSuite, Commit, Discussion, Issue, PullRequest, Release,
+# RepositoryVulnerabilityAlert, ...
+
+# ====================== set variables =======================
+
 # The minimum fzf version that the user needs to run all interactive commands.
 MIN_FZF_VERSION="0.29.0"
 
@@ -11,28 +22,36 @@ export GH_REST_API_VERSION="X-GitHub-Api-Version:2022-11-28"
 # Enable terminal-style output even when the output is redirected.
 export GH_FORCE_TTY=1
 
-# NotificationReason:
-# assign, author, comment, invitation, manual, mention, review_requested, security_alert, state_change, subscribed, team_mention, ci_activity
-# NotificationSubjectTypes:
-# CheckSuite, Commit, Discussion, Issue, PullRequest, Release, RepositoryVulnerabilityAlert, ...
-
-die() {
-    echo ERROR: "$*" >&2
-    exit 1
-}
-
 # 'SHLVL' variable represents the nesting level of the current shell
 export NESTED_START_LVL="$SHLVL"
 export FINAL_MSG='All caught up!'
+
 # color codes
 export GREEN='\033[0;32m'
 export DARK_GRAY='\033[0;90m'
 export NC='\033[0m'
 export WHITE_BOLD='\033[1m'
 
+export exclusion_string='XXX_BOGUS_STRING_THAT_SHOULD_NOT_EXIST_XXX'
+export filter_string=''
+export num_notifications='0'
+export only_participating_flag='false'
+export include_all_flag='false'
+export preview_window_visibility='hidden'
+# not necessarily to be exported, since they are not used in any child process
+print_static_flag='false'
+mark_read_flag='false'
+update_subscription_url=''
+
+# ===================== basic functions =====================
+
+die() {
+    echo ERROR: "$*" >&2
+    exit 1
+}
+
 # Create help message with colored text
 # IMPORTANT: Keep it synchronized with the README, but without the Examples.
-# IMPORTANT: Use an unquoted delimiter (EOF) to have the variables expanded.
 print_help_text() {
     local help_text
     help_text=$(
@@ -76,16 +95,7 @@ EOF
     echo -e "$help_text"
 }
 
-export exclusion_string='XXX_BOGUS_STRING_THAT_SHOULD_NOT_EXIST_XXX'
-export filter_string=''
-export num_notifications='0'
-export only_participating_flag='false'
-export include_all_flag='false'
-export preview_window_visibility='hidden'
-# not necessarily to be exported, since they are not used in any child process
-print_static_flag='false'
-mark_read_flag='false'
-update_subscription_url=''
+# ====================== parse command-line options =======================
 
 while getopts 'e:f:n:u:pawhsr' flag; do
     case "${flag}" in
@@ -107,6 +117,8 @@ while getopts 'e:f:n:u:pawhsr' flag; do
             ;;
     esac
 done
+
+# ===================== helper functions ==========================
 
 get_notifs() {
     local page_num local_page_size
@@ -337,14 +349,9 @@ select_notif() {
     # and so the lines would get screwed up and fail if we don't take that into account.
     output=$(
         SHELL="$(which bash)" fzf <<<"$1" \
-            --ansi --no-multi --with-nth 5.. \
-            --delimiter '\s+' --print-query \
-            --reverse --info=inline --pointer="▶" \
-            --border horizontal --color "border:dim" \
-            --header "? help · esc quit" --color "header:green:italic:dim" \
-            --prompt "GitHub Notifications > " --color "prompt:80,info:40" \
+            --ansi \
+            --bind "btab:change-preview-window(75%:nohidden|75%:down:nohidden:border-top|nohidden)" \
             --bind "change:first" \
-            --bind "?:toggle-preview+change-preview:print_help_text" \
             --bind "ctrl-a:execute-silent(mark_all_read {})+reload:print_notifs || true" \
             --bind "ctrl-b:execute-silent:open_in_browser {}" \
             --bind "ctrl-d:toggle-preview+change-preview:if grep -q PullRequest <<<{8}; then gh pr diff {9} --repo {7}  | diff_pager; else view_notification {}; fi" \
@@ -353,10 +360,23 @@ select_notif() {
             --bind "ctrl-t:execute-silent(mark_individual_read {})+reload:print_notifs || true" \
             --bind "enter:execute:view_notification --all_comments {} | less ${less_args[*]} >/dev/tty" \
             --bind "tab:toggle-preview+change-preview:view_notification {}" \
-            --bind "btab:change-preview-window(75%:nohidden|75%:down:nohidden:border-top|nohidden)" \
-            --preview-window "wrap:${preview_window_visibility}:50%:right:border-left:<65(wrap:${preview_window_visibility}:75%:down:border-top)" \
+            --bind "?:toggle-preview+change-preview:print_help_text" \
+            --border horizontal \
+            --color "border:dim" \
+            --color "header:green:italic:dim" \
+            --color "prompt:80,info:40" \
+            --delimiter '\s+' \
+            --expect "esc,ctrl-x" \
+            --header "? help · esc quit" \
+            --info=inline \
+            --no-multi \
+            --pointer="▶" \
             --preview "view_notification {}" \
-            --expect "esc,ctrl-x"
+            --preview-window "wrap:${preview_window_visibility}:50%:right:border-left:<65(wrap:${preview_window_visibility}:75%:down:border-top)" \
+            --print-query \
+            --prompt "GitHub Notifications > " \
+            --reverse \
+            --with-nth 5..
     )
     # actions that close fzf are defined below
     # 1st line ('--print-query'): the input query string

--- a/readme.md
+++ b/readme.md
@@ -44,21 +44,21 @@ gh notify [Flags]
 
 ### Key Bindings fzf
 
-| Keys                           | Description                                               |
-| ------------------------------ | --------------------------------------------------------- |
-| <kbd>?</kbd>                   | toggle help                                               |
-| <kbd>enter</kbd>               | print the selected notification, mark it as read and quit |
-| <kbd>tab</kbd>                 | toggle notification preview                               |
-| <kbd>shift</kbd><kbd>tab</kbd> | resize the preview window                                 |
-| <kbd>shift</kbd><kbd>↑↓</kbd>  | scroll the preview up/ down                               |
-| <kbd>ctrl</kbd><kbd>a</kbd>    | mark all displayed notifications as read and reload       |
-| <kbd>ctrl</kbd><kbd>b</kbd>    | browser                                                   |
-| <kbd>ctrl</kbd><kbd>d</kbd>    | view diff                                                 |
-| <kbd>ctrl</kbd><kbd>p</kbd>    | view diff in patch format                                 |
-| <kbd>ctrl</kbd><kbd>r</kbd>    | reload                                                    |
-| <kbd>ctrl</kbd><kbd>t</kbd>    | mark the selected notification as read and reload         |
-| <kbd>ctrl</kbd><kbd>x</kbd>    | write a comment with the editor and quit                  |
-| <kbd>esc</kbd>                 | quit                                                      |
+| Keys                           | Description                                         |
+| ------------------------------ | --------------------------------------------------- |
+| <kbd>?</kbd>                   | toggle help                                         |
+| <kbd>enter</kbd>               | view the selected notification in the 'less' pager  |
+| <kbd>tab</kbd>                 | toggle notification preview                         |
+| <kbd>shift</kbd><kbd>tab</kbd> | resize the preview window                           |
+| <kbd>shift</kbd><kbd>↑↓</kbd>  | scroll the preview up/ down                         |
+| <kbd>ctrl</kbd><kbd>a</kbd>    | mark all displayed notifications as read and reload |
+| <kbd>ctrl</kbd><kbd>b</kbd>    | browser                                             |
+| <kbd>ctrl</kbd><kbd>d</kbd>    | view diff                                           |
+| <kbd>ctrl</kbd><kbd>p</kbd>    | view diff in patch format                           |
+| <kbd>ctrl</kbd><kbd>r</kbd>    | reload                                              |
+| <kbd>ctrl</kbd><kbd>t</kbd>    | mark the selected notification as read and reload   |
+| <kbd>ctrl</kbd><kbd>x</kbd>    | write a comment with the editor and quit            |
+| <kbd>esc</kbd>                 | quit                                                |
 
 ---
 ## Customizations

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,11 @@ gh ext remove meiji163/gh-notify
 
 - to use `gh notify` interactively also install these tools
   - [Fuzzy Finder (fzf)](https://github.com/junegunn/fzf#installation)
-  - [Python](https://www.python.org/) in cases where `gh` can't open the `URL` in your browser, this oneliner is used as a cross-platform solution: `python -m webbrowser <URL>`
+  - [Less pager](http://greenwoodsoftware.com/less/download.html), is usually installed by
+    default on Linux and macOS
+  - [Python](https://www.python.org/) in cases where `gh` can't open the `URL` in your
+    browser, this oneliner is used as a cross-platform solution: `python -m webbrowser
+    <URL>`
 
 ## Usage
 


### PR DESCRIPTION
- readjust the <kbd>⏎ Enter</kbd> key to display the notification in the `less` pager including all comments for Issues/PR's
- the preview will diplay a notification without the '--coments' flag, which loads it faster

---

- testing this week, intended to merge next week
