### PR TITLE
fix: provide default value for LESS

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -316,7 +316,7 @@ select_notif() {
     # '-F/--quit-if-one-screen' option. The screen will not stay open for small
     # text files that fit on the entire screen. The easiest solution is to
     # disable the 'LESS' variable and define common sense options.
-    [[ -n ${LESS:-} ]] && unset LESS
+    [[ -n ${LESS-} ]] && unset LESS
     less_args=(
         "--clear-screen"      # painted from the top line down
         "--LONG-PROMPT"       # Long prompts ("Line X of Y")

--- a/gh-notify
+++ b/gh-notify
@@ -316,7 +316,7 @@ select_notif() {
     # '-F/--quit-if-one-screen' option. The screen will not stay open for small
     # text files that fit on the entire screen. The easiest solution is to
     # disable the 'LESS' variable and define common sense options.
-    [[ -n $LESS ]] && unset LESS
+    [[ -n ${LESS:-} ]] && unset LESS
     less_args=(
         "--clear-screen"      # painted from the top line down
         "--LONG-PROMPT"       # Long prompts ("Line X of Y")


### PR DESCRIPTION
#### description
- fix #71
- `set -o nounset` in bash throws an error if a variable is not set
  - providing a default value should fix the issue ~~`"${LESS:-}"`~~ `"${LESS-}"`

---

> [!NOTE]
> `luizm/action-sh-checker` currently uses version `3.6.0` as the `shfmt` version, where
> as in `3.7.0` the change was made to allow `${LESS:-}`  again.
