### PR TITLE
Mark done

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -31,11 +31,11 @@ GH_NOTIFY_PER_PAGE_LIMIT=50
 : "${GH_NOTIFY_MARK_ALL_READ_KEY:=ctrl-a}"
 : "${GH_NOTIFY_OPEN_BROWSER_KEY:=ctrl-b}"
 : "${GH_NOTIFY_VIEW_DIFF_KEY:=ctrl-d}"
+: "${GH_NOTIFY_COMMENT_KEY:=ctrl-o}"
 : "${GH_NOTIFY_VIEW_PATCH_KEY:=ctrl-p}"
 : "${GH_NOTIFY_RELOAD_KEY:=ctrl-r}"
 : "${GH_NOTIFY_MARK_READ_KEY:=ctrl-t}"
 : "${GH_NOTIFY_MARK_DONE_KEY:=ctrl-x}"
-: "${GH_NOTIFY_COMMENT_KEY:=ctrl-c}"
 : "${GH_NOTIFY_TOGGLE_KEY:=ctrl-y}"
 : "${GH_NOTIFY_RESIZE_PREVIEW_KEY:=btab}"
 : "${GH_NOTIFY_VIEW_KEY:=enter}"
@@ -160,11 +160,11 @@ ${WHITE_BOLD}Key Bindings fzf${NC}
   ${GREEN}${GH_NOTIFY_MARK_ALL_READ_KEY}   ${NC}  mark all displayed notifications as read and reload
   ${GREEN}${GH_NOTIFY_OPEN_BROWSER_KEY}   ${NC}  browser
   ${GREEN}${GH_NOTIFY_VIEW_DIFF_KEY}   ${NC}  view diff
+  ${GREEN}${GH_NOTIFY_COMMENT_KEY}   ${NC}  write a comment with the editor and quit
   ${GREEN}${GH_NOTIFY_VIEW_PATCH_KEY}   ${NC}  view diff in patch format
   ${GREEN}${GH_NOTIFY_RELOAD_KEY}   ${NC}  reload
   ${GREEN}${GH_NOTIFY_MARK_READ_KEY}   ${NC}  mark the selected notification as read and reload
   ${GREEN}${GH_NOTIFY_MARK_DONE_KEY}   ${NC}  mark the selected notification as done and reload
-  ${GREEN}${GH_NOTIFY_COMMENT_KEY}   ${NC}  write a comment with the editor and quit
   ${GREEN}${GH_NOTIFY_TOGGLE_KEY}   ${NC}  toggle the selected notification
   ${GREEN}esc      ${NC}  quit
 
@@ -521,6 +521,7 @@ mark_individual_read() {
     done <"$1"
 
     if [[ ${#array_threads[@]} -eq 1 ]]; then
+        # https://docs.github.com/en/rest/activity/notifications#mark-repository-notifications-as-read
         gh_rest_api --silent --method PATCH "notifications/threads/${array_threads[0]}" ||
             die "Failed to mark notifications as read."
     elif [[ ${#array_threads[@]} -gt 1 ]]; then
@@ -542,18 +543,23 @@ mark_individual_read() {
 
 mark_individual_done() {
     local thread_id thread_state
-    # TODO: Investigate potential rate-limiting issues when sending too many requests in short
-    # succession. I didn't encounter any rate-limiting when testing with 100 unread notifications,
-    # but further testing is needed to be sure.
-
-    # Running commands in the background of a script can cause it to hang, especially if the
-    # command outputs to stdout: https://tldp.org/LDP/abs/html/x9644.html#WAITHANG
-    while IFS=' ' read -r _ thread_id thread_state _; do
-        if [[ $thread_state == "UNREAD" ]]; then
-            # https://docs.github.com/en/rest/activity/notifications#mark-a-thread-as-done
-            gh_rest_api --silent --method DELETE "notifications/threads/${thread_id}" &>/dev/null &
-        fi
+    declare -a array_threads=()
+    while IFS=' ' read -r _ thread_id _; do
+        array_threads+=("$thread_id")
     done <"$1"
+
+    if [[ ${#array_threads[@]} -eq 1 ]]; then
+        # https://docs.github.com/en/rest/activity/notifications#mark-a-thread-as-done
+        gh_rest_api --silent --method DELETE "notifications/threads/${array_threads[0]}" ||
+            die "Failed to mark notifications as read."
+    elif [[ ${#array_threads[@]} -gt 1 ]]; then
+        for ((i = 0; i < ${#array_threads[@]}; i += 30)); do
+            for j in "${array_threads[@]:i:30}"; do
+                gh_rest_api --silent --method DELETE "notifications/threads/${j}" &>/dev/null &
+            done
+            command sleep 0.3
+        done
+    fi
 }
 
 select_notif() {

--- a/gh-notify
+++ b/gh-notify
@@ -34,7 +34,8 @@ GH_NOTIFY_PER_PAGE_LIMIT=50
 : "${GH_NOTIFY_VIEW_PATCH_KEY:=ctrl-p}"
 : "${GH_NOTIFY_RELOAD_KEY:=ctrl-r}"
 : "${GH_NOTIFY_MARK_READ_KEY:=ctrl-t}"
-: "${GH_NOTIFY_COMMENT_KEY:=ctrl-x}"
+: "${GH_NOTIFY_MARK_DONE_KEY:=ctrl-x}"
+: "${GH_NOTIFY_COMMENT_KEY:=ctrl-c}"
 : "${GH_NOTIFY_TOGGLE_KEY:=ctrl-y}"
 : "${GH_NOTIFY_RESIZE_PREVIEW_KEY:=btab}"
 : "${GH_NOTIFY_VIEW_KEY:=enter}"
@@ -162,6 +163,7 @@ ${WHITE_BOLD}Key Bindings fzf${NC}
   ${GREEN}${GH_NOTIFY_VIEW_PATCH_KEY}   ${NC}  view diff in patch format
   ${GREEN}${GH_NOTIFY_RELOAD_KEY}   ${NC}  reload
   ${GREEN}${GH_NOTIFY_MARK_READ_KEY}   ${NC}  mark the selected notification as read and reload
+  ${GREEN}${GH_NOTIFY_MARK_DONE_KEY}   ${NC}  mark the selected notification as done and reload
   ${GREEN}${GH_NOTIFY_COMMENT_KEY}   ${NC}  write a comment with the editor and quit
   ${GREEN}${GH_NOTIFY_TOGGLE_KEY}   ${NC}  toggle the selected notification
   ${GREEN}esc      ${NC}  quit
@@ -538,6 +540,22 @@ mark_individual_read() {
     fi
 }
 
+mark_individual_done() {
+    local thread_id thread_state
+    # TODO: Investigate potential rate-limiting issues when sending too many requests in short
+    # succession. I didn't encounter any rate-limiting when testing with 100 unread notifications,
+    # but further testing is needed to be sure.
+
+    # Running commands in the background of a script can cause it to hang, especially if the
+    # command outputs to stdout: https://tldp.org/LDP/abs/html/x9644.html#WAITHANG
+    while IFS=' ' read -r _ thread_id thread_state _; do
+        if [[ $thread_state == "UNREAD" ]]; then
+            # https://docs.github.com/en/rest/activity/notifications#mark-a-thread-as-done
+            gh_rest_api --silent --method DELETE "notifications/threads/${thread_id}" &>/dev/null &
+        fi
+    done <"$1"
+}
+
 select_notif() {
     local output expected_key selected_line repo_full_name type num
     # Export functions to child processes. 'fzf' executes commands with $SHELL -c; to ensure
@@ -546,6 +564,7 @@ select_notif() {
     export -f process_page process_discussion process_url gh_rest_api
     export -f highlight_output open_in_browser view_notification view_in_pager
     export -f mark_all_read mark_individual_read
+    export -f mark_individual_done
     # The 'die' function is not exported because 'fzf' warns you about the error in
     # a failed 'print_notifs' call, but does not display the message.
 
@@ -561,6 +580,7 @@ select_notif() {
             --bind "${GH_NOTIFY_VIEW_PATCH_KEY}:toggle-preview+change-preview:if command grep -q PullRequest <<<{10}; then command gh pr diff {11} --patch --repo {5} | highlight_output; else view_notification {}; fi" \
             --bind "${GH_NOTIFY_RELOAD_KEY}:reload:print_notifs || true" \
             --bind "${GH_NOTIFY_MARK_READ_KEY}:execute-silent(mark_individual_read {+f})+reload:print_notifs || true" \
+            --bind "${GH_NOTIFY_MARK_DONE_KEY}:execute-silent(mark_individual_done {+f})+reload:print_notifs || true" \
             --bind "${GH_NOTIFY_TOGGLE_KEY}:toggle+down" \
             --bind "${GH_NOTIFY_VIEW_KEY}:execute:view_in_pager {}" \
             --bind "${GH_NOTIFY_TOGGLE_PREVIEW_KEY}:toggle-preview+change-preview:view_notification {}" \

--- a/readme.md
+++ b/readme.md
@@ -58,10 +58,11 @@ gh notify [Flags]
 | <kbd>ctrl</kbd><kbd>a</kbd>    | mark all displayed notifications as read and reload | `GH_NOTIFY_MARK_ALL_READ_KEY`      |
 | <kbd>ctrl</kbd><kbd>b</kbd>    | browser                                             | `GH_NOTIFY_OPEN_BROWSER_KEY`       |
 | <kbd>ctrl</kbd><kbd>d</kbd>    | view diff                                           | `GH_NOTIFY_VIEW_DIFF_KEY`          |
+| <kbd>ctrl</kbd><kbd>o</kbd>    | write a comment with the editor and quit            | `GH_NOTIFY_COMMENT_KEY`            |
 | <kbd>ctrl</kbd><kbd>p</kbd>    | view diff in patch format                           | `GH_NOTIFY_VIEW_PATCH_KEY`         |
 | <kbd>ctrl</kbd><kbd>r</kbd>    | reload                                              | `GH_NOTIFY_RELOAD_KEY`             |
 | <kbd>ctrl</kbd><kbd>t</kbd>    | mark the selected notification as read and reload   | `GH_NOTIFY_MARK_READ_KEY`          |
-| <kbd>ctrl</kbd><kbd>x</kbd>    | write a comment with the editor and quit            | `GH_NOTIFY_COMMENT_KEY`            |
+| <kbd>ctrl</kbd><kbd>x</kbd>    | mark the selected notification as done and reload   | `GH_NOTIFY_MARK_DONE_KEY`          |
 | <kbd>ctrl</kbd><kbd>y</kbd>    | toggle the selected notification                    | `GH_NOTIFY_TOGGLE_KEY`             |
 | <kbd>esc</kbd>                 | quit                                                |                                    |
 


### PR DESCRIPTION
Allow the user to select and delete/done notifications with ctrl-x.
I changed individual Done to ctrl-x and comment to ctrl-c. Not sure about what are good keys for that.
in continuation of https://github.com/meiji163/gh-notify/pull/90.