### PR TITLE
fix: checking version was too strict

### DIFF
--- a/gh-notify
+++ b/gh-notify
@@ -627,6 +627,10 @@ check_version() {
     IFS='.' read -ra threshold_parts <<<"$threshold"
 
     for i in "${!threshold_parts[@]}"; do
+        # If the threshold's last part is 0 and version has one less parts, it's ok
+        if (( i == ${#threshold_parts[@]} - 1 )) && ((${#ver_parts[@]} == ${#threshold_parts[@]} - 1)) && ((${threshold_parts[i]} == 0)); then
+            break
+        fi
         if ((i >= ${#ver_parts[@]})) || ((ver_parts[i] < threshold_parts[i])); then
             $on_error "Your '$tool' version '$user_version' is insufficient. The minimum required version is '$threshold'."
         elif ((ver_parts[i] > threshold_parts[i])); then

--- a/gh-notify
+++ b/gh-notify
@@ -617,7 +617,7 @@ select_notif() {
 # This function validates the version of a tool.
 check_version() {
     local tool=$1 threshold=$2 on_error=${3:-die}
-    local user_version
+    local user_version user_version_part index
     declare -a ver_parts threshold_parts
     user_version=$(command $tool --version 2>&1 |
         command command grep --color=never --extended-regexp --only-matching --regexp='[0-9]+(\.[0-9]+)*' |
@@ -626,14 +626,11 @@ check_version() {
     IFS='.' read -ra ver_parts <<<"$user_version"
     IFS='.' read -ra threshold_parts <<<"$threshold"
 
-    for i in "${!threshold_parts[@]}"; do
-        # If the threshold's last part is 0 and version has one less parts, it's ok
-        if (( i == ${#threshold_parts[@]} - 1 )) && ((${#ver_parts[@]} == ${#threshold_parts[@]} - 1)) && ((${threshold_parts[i]} == 0)); then
-            break
-        fi
-        if ((i >= ${#ver_parts[@]})) || ((ver_parts[i] < threshold_parts[i])); then
+    for index in "${!threshold_parts[@]}"; do
+        user_version_part=${ver_parts[index]:-0}
+        if ((user_version_part < threshold_parts[index])); then
             $on_error "Your '$tool' version '$user_version' is insufficient. The minimum required version is '$threshold'."
-        elif ((ver_parts[i] > threshold_parts[i])); then
+        elif ((user_version_part > threshold_parts[index])); then
             break
         fi
     done

--- a/gh-notify
+++ b/gh-notify
@@ -620,7 +620,7 @@ check_version() {
     local user_version user_version_part index
     declare -a ver_parts threshold_parts
     user_version=$(command $tool --version 2>&1 |
-        command command grep --color=never --extended-regexp --only-matching --regexp='[0-9]+(\.[0-9]+)*' |
+        command grep --color=never --extended-regexp --only-matching --regexp='[0-9]+(\.[0-9]+)*' |
         command sed q)
 
     IFS='.' read -ra ver_parts <<<"$user_version"


### PR DESCRIPTION
In my system I have, for some reasons, a developer version of `fzf`:
```sh
> fzf --version
0.29 (devel)
```
Although this version meets the minimum required version of 0.29.0 specified by `MIN_FZF_VERSION="0.29.0"`, the `check_version` function incorrectly fails the check.

This PR addresses the issue by modifying the check_version function. Specifically, the function now allows the version check to pass when the **installed version has one fewer segment** than the threshold version, provided that the **missing segment in the threshold version is 0**. For instance, if the threshold version is 0.29.0, then an installed version of 0.29 is considered sufficient, as the **trailing 0 does not imply a higher version requirement**.

Therefore my additional check 
```bash
if (( i == ${#threshold_parts[@]} - 1 )) && ((${#ver_parts[@]} == ${#threshold_parts[@]} - 1)) && ((${threshold_parts[i]} == 0));
```
result in the case `tool=0.29` (2 parts) and `threshold=0.29.0` (3 parts) and `i=2` in
```bash
if (( 2 == 3-1 )) && ((2 == 3-1)) && ((0 == 0));
```